### PR TITLE
Update to support Agent 1.3.1

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -77,7 +77,7 @@ func AgentTarball() string {
 
 // AgentRemoteTarball is the remote location of the Agent image, used for populating the cache
 func AgentRemoteTarball() string {
-	return "https://s3.amazonaws.com/" + s3Bucket + "/ecs-agent-v1.3.0.tar"
+	return "https://s3.amazonaws.com/" + s3Bucket + "/ecs-agent-v1.3.1.tar"
 }
 
 // AgentRemoteTarballMD5 is the remote location of a md5sum used to verify the integrity of the AgentRemoteTarball

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 Name:           ecs-init
-Version:        1.3.0
+Version:        1.3.1
 Release:        1%{?dist}
 Group:          System Environment/Base
 Vendor:         Amazon.com
@@ -132,6 +132,9 @@ if [ -e %{running_semaphore} ]; then
 fi
 
 %changelog
+* Thu Jul 30 2015 Samuel Karp <skarp@amazon.com> - 1.3.1-1
+- Cache Agent version 1.3.1
+- Read Docker endpoint from environment variable DOCKER_HOST if present
 * Thu Jul 2 2015 Samuel Karp <skarp@amazon.com> - 1.3.0-1
 - Cache Agent version 1.3.0
 * Fri Jun 19 2015 Euan Kemp <euank@amazon.com> - 1.2.1-2


### PR DESCRIPTION
- Cache Agent version 1.3.1
- Read Docker endpoint from environment variable DOCKER_HOST if present

r? @euank @aaithal 