### PR TITLE
Add default logging drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 go:
     - 1.4
 before_install: ./scripts/hack/symlink-gopath-travisci

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -136,11 +136,12 @@ func (c *Client) getContainerConfig() *godocker.Config {
 
 	// default environment variables
 	envVariables := map[string]string{
-		"ECS_LOGFILE":                logDir + "/" + config.AgentLogFile,
-		"ECS_DATADIR":                dataDir,
-		"ECS_AGENT_CONFIG_FILE_PATH": config.AgentJSONConfigFile(),
-		"ECS_UPDATE_DOWNLOAD_DIR":    config.CacheDirectory(),
-		"ECS_UPDATES_ENABLED":        "true",
+		"ECS_LOGFILE":                   logDir + "/" + config.AgentLogFile,
+		"ECS_DATADIR":                   dataDir,
+		"ECS_AGENT_CONFIG_FILE_PATH":    config.AgentJSONConfigFile(),
+		"ECS_UPDATE_DOWNLOAD_DIR":       config.CacheDirectory(),
+		"ECS_UPDATES_ENABLED":           "true",
+		"ECS_AVAILABLE_LOGGING_DRIVERS": "[\"json-file\",\"syslog\"]",
 	}
 
 	// merge in user-supplied environment variables

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -224,6 +224,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_AGENT_CONFIG_FILE_PATH="+config.AgentJSONConfigFile(), envVariables, t)
 	expectKey("ECS_UPDATE_DOWNLOAD_DIR="+config.CacheDirectory(), envVariables, t)
 	expectKey("ECS_UPDATES_ENABLED=true", envVariables, t)
+	expectKey("ECS_AVAILABLE_LOGGING_DRIVERS=[\"json-file\",\"syslog\"]", envVariables, t)
 
 	if len(cfg.ExposedPorts) != 1 {
 		t.Errorf("Expected exactly 1 element to be in ExposedPorts, but was %d", len(cfg.ExposedPorts))


### PR DESCRIPTION
Add default logging drivers `json-file` and `syslog`.  Also includes a commit that better-handles user-supplied environment variables.

r? @euank 