### PR TITLE
Separate system paths for build logic control

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -91,11 +91,11 @@ func DesiredImageLocatorFile() string {
 }
 
 func CgroupDirectory() string {
-	return "/cgroup"
+	return cgroupDirectory
 }
 
 func ExecDriverDirectory() string {
-	return "/var/run/docker/execdriver"
+	return execDriverDirectory
 }
 
 func DockerUnixSocket() string {

--- a/ecs-init/config/default_system_paths.go
+++ b/ecs-init/config/default_system_paths.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+const (
+	cgroupDirectory     = "/cgroup"
+	execDriverDirectory = "/var/run/docker/execdriver"
+)

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -21,9 +21,13 @@ export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-init"
 mkdir -p "${SRCPATH}"
 ln -s "${TOPWD}/ecs-init" "${SRCPATH}"
 cd "${SRCPATH}/ecs-init"
-if [ "$1" = "dev" ]; then
+if [[ "$1" == "dev" ]]; then
 	go build -tags 'development' -o "${TOPWD}/amazon-ecs-init"
 else
-	CGO_ENABLED=0 go build -a -x -ldflags '-s' -o "${TOPWD}/amazon-ecs-init"
+	tags=""
+	if [[ "$1" != "" ]]; then
+		tags="-tags '$1'"
+	fi
+	CGO_ENABLED=0 go build -a ${tags} -x -ldflags '-s' -o "${TOPWD}/amazon-ecs-init"
 fi
 rm -r "${BUILDDIR}"


### PR DESCRIPTION
This should help enable conditional compilation for other systems which have made different choices for the `cgroup` and `execdriver` paths.

This is intended to help with #23 if different `cgroup` and `execdriver` paths are needed there.

r? @euank 