### PR TITLE
Update to support Agent 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 go:
     - 1.4
 before_install: ./scripts/hack/symlink-gopath-travisci

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -91,11 +91,11 @@ func DesiredImageLocatorFile() string {
 }
 
 func CgroupDirectory() string {
-	return "/cgroup"
+	return cgroupDirectory
 }
 
 func ExecDriverDirectory() string {
-	return "/var/run/docker/execdriver"
+	return execDriverDirectory
 }
 
 func DockerUnixSocket() string {

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -77,7 +77,7 @@ func AgentTarball() string {
 
 // AgentRemoteTarball is the remote location of the Agent image, used for populating the cache
 func AgentRemoteTarball() string {
-	return "https://s3.amazonaws.com/" + s3Bucket + "/ecs-agent-v1.4.0.tar"
+	return "https://s3.amazonaws.com/" + s3Bucket + "/ecs-agent-v1.5.0.tar"
 }
 
 // AgentRemoteTarballMD5 is the remote location of a md5sum used to verify the integrity of the AgentRemoteTarball

--- a/ecs-init/config/default_system_paths.go
+++ b/ecs-init/config/default_system_paths.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+const (
+	cgroupDirectory     = "/cgroup"
+	execDriverDirectory = "/var/run/docker/execdriver"
+)

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -136,11 +136,12 @@ func (c *Client) getContainerConfig() *godocker.Config {
 
 	// default environment variables
 	envVariables := map[string]string{
-		"ECS_LOGFILE":                logDir + "/" + config.AgentLogFile,
-		"ECS_DATADIR":                dataDir,
-		"ECS_AGENT_CONFIG_FILE_PATH": config.AgentJSONConfigFile(),
-		"ECS_UPDATE_DOWNLOAD_DIR":    config.CacheDirectory(),
-		"ECS_UPDATES_ENABLED":        "true",
+		"ECS_LOGFILE":                   logDir + "/" + config.AgentLogFile,
+		"ECS_DATADIR":                   dataDir,
+		"ECS_AGENT_CONFIG_FILE_PATH":    config.AgentJSONConfigFile(),
+		"ECS_UPDATE_DOWNLOAD_DIR":       config.CacheDirectory(),
+		"ECS_UPDATES_ENABLED":           "true",
+		"ECS_AVAILABLE_LOGGING_DRIVERS": "[\"json-file\",\"syslog\"]",
 	}
 
 	// merge in user-supplied environment variables

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -224,6 +224,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_AGENT_CONFIG_FILE_PATH="+config.AgentJSONConfigFile(), envVariables, t)
 	expectKey("ECS_UPDATE_DOWNLOAD_DIR="+config.CacheDirectory(), envVariables, t)
 	expectKey("ECS_UPDATES_ENABLED=true", envVariables, t)
+	expectKey("ECS_AVAILABLE_LOGGING_DRIVERS=[\"json-file\",\"syslog\"]", envVariables, t)
 
 	if len(cfg.ExposedPorts) != 1 {
 		t.Errorf("Expected exactly 1 element to be in ExposedPorts, but was %d", len(cfg.ExposedPorts))

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 Name:           ecs-init
-Version:        1.4.0
-Release:        2%{?dist}
+Version:        1.5.0
+Release:        1%{?dist}
 Group:          System Environment/Base
 Vendor:         Amazon.com
 License:        Apache 2.0
@@ -147,6 +147,10 @@ if [ -e %{running_semaphore} ]; then
 fi
 
 %changelog
+* Wed Sep 23 2015 Samuel Karp <skarp@amazon.com> - 1.5.0-1
+- Cache Agent version 1.5.0
+- Improved merge strategy for user-supplied environment variables
+- Add default supported logging drivers
 * Wed Aug 26 2015 Samuel Karp <skarp@amazon.com> - 1.4.0-2
 - Add support for Docker 1.7.1
 * Tue Aug 11 2015 Samuel Karp <skarp@amazon.com> - 1.4.0-1

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -31,6 +31,21 @@ Requires:       docker >= 1.6.0, docker <= 1.7.1
 Requires:       upstart
 Requires(post): docker >= 1.6.0
 
+Provides:       bundled(docker)
+Provides:       bundled(golang(github.com/docker/docker/pkg/archive))
+Provides:       bundled(golang(github.com/docker/docker/pkg/fileutils))
+Provides:       bundled(golang(github.com/docker/docker/pkg/ioutils))
+Provides:       bundled(golang(github.com/docker/docker/pkg/pools))
+Provides:       bundled(golang(github.com/docker/docker/pkg/promise))
+Provides:       bundled(golang(github.com/docker/docker/pkg/system))
+Provides:       bundled(golang(github.com/docker/docker/pkg/units))
+Provides:       bundled(golang(github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar))
+Provides:       bundled(golang(github.com/fsouza/go-dockerclient))
+Provides:       bundled(golang(code.google.com/p/gomock/gomock))
+Provides:       bundled(golang-logrus)
+Provides:       bundled(golang(github.com/Sirupsen/logrus))
+Provides:       bundled(golang(github.com/cihub/seelog))
+
 %global init_dir %{_sysconfdir}/init
 %global bin_dir %{_libexecdir}
 %global	conf_dir %{_sysconfdir}/ecs

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -21,9 +21,13 @@ export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-init"
 mkdir -p "${SRCPATH}"
 ln -s "${TOPWD}/ecs-init" "${SRCPATH}"
 cd "${SRCPATH}/ecs-init"
-if [ "$1" = "dev" ]; then
+if [[ "$1" == "dev" ]]; then
 	go build -tags 'development' -o "${TOPWD}/amazon-ecs-init"
 else
-	CGO_ENABLED=0 go build -a -x -ldflags '-s' -o "${TOPWD}/amazon-ecs-init"
+	tags=""
+	if [[ "$1" != "" ]]; then
+		tags="-tags '$1'"
+	fi
+	CGO_ENABLED=0 go build -a ${tags} -x -ldflags '-s' -o "${TOPWD}/amazon-ecs-init"
 fi
 rm -r "${BUILDDIR}"


### PR DESCRIPTION
- Cache Agent version 1.5.0
- Improved merge strategy for user-supplied environment variables
- Add default supported logging drivers

r? @euank @aaithal 