### PR TITLE
Do not overwrite /etc/init/ecs.conf on upgrades if it was modified

### DIFF
--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -70,7 +70,7 @@ touch $RPM_BUILD_ROOT/%{cache_dir}/state
 
 %files
 %defattr(-,root,root,-)
-%{init_dir}/ecs.conf
+%config(noreplace) %{init_dir}/ecs.conf
 %{bin_dir}/amazon-ecs-init
 %{man_dir}/amazon-ecs-init.1.gz
 %config(noreplace) %ghost %{conf_dir}/ecs.config


### PR DESCRIPTION
  Our [Weave ECS AMIs](https://github.com/weaveworks/integrations/tree/master/aws/ecs) use a [modified version of `/etc/init/ecs.conf`](https://github.com/weaveworks/integrations/blob/master/aws/ecs/packer/to-upload/ecs.conf) to make sure that the ecs-agent talks to the weave proxy instead of docker directly.

However, we've noticed that `ecs.conf` gets overwritten on upgrades: weaveworks/integrations#4

This breaks the expected behaviour of our AMI, resulting in the `ecs-agent` talking to the docker daemon directly and bypassing our proxy.
