### PR TITLE
Changes to SUSE packaging for 1.5.0+

### DIFF
--- a/ecs-init/config/suse_system_paths.go
+++ b/ecs-init/config/suse_system_paths.go
@@ -1,4 +1,4 @@
-// +build !suse
+// +build suse
 
 // Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -16,6 +16,6 @@
 package config
 
 const (
-	cgroupDirectory     = "/cgroup"
+	cgroupDirectory     = "/sys/fs/cgroup"
 	execDriverDirectory = "/var/run/docker/execdriver"
 )

--- a/packaging/suse/amazon-ecs-init.spec
+++ b/packaging/suse/amazon-ecs-init.spec
@@ -17,7 +17,7 @@
 
 %define short_name amazon-ecs
 Name:           amazon-ecs-init
-Version:        1.4.0
+Version:        1.5.0
 Release:        0
 Summary:        Amazon EC2 Container Service Initialization
 License:        Apache-2.0
@@ -44,7 +44,7 @@ Amazon EC2.
 %patch1
 
 %build
-./scripts/gobuild.sh
+./scripts/gobuild.sh suse
 gzip -c scripts/amazon-ecs-init.1 > scripts/amazon-ecs-init.1.gz
 
 %install

--- a/packaging/suse/cgroup_location.patch
+++ b/packaging/suse/cgroup_location.patch
@@ -1,11 +1,33 @@
---- ecs-init/config/common.go.orig
-+++ ecs-init/config/common.go
-@@ -91,7 +91,7 @@ func DesiredImageLocatorFile() string {
- }
- 
- func CgroupDirectory() string {
--	return "/cgroup"
-+	return "/sys/fs/cgroup"
- }
- 
- func ExecDriverDirectory() string {
+--- ecs-init/config/default_system_paths.go.orig
++++ ecs-init/config/default_system_paths.go
+@@ -1,3 +1,5 @@
++// +build !suse
++
+ // Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License"). You may
+
+--- /dev/null
++++ ecs-init/config/suse_system_paths.go
+@@ -0,0 +1,21 @@
++// +build suse
++
++// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License"). You may
++// not use this file except in compliance with the License. A copy of the
++// License is located at
++//
++// http://aws.amazon.com/apache2.0/
++//
++// or in the "license" file accompanying this file. This file is distributed
++// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
++// express or implied. See the License for the specific language governing
++// permissions and limitations under the License.
++
++package config
++
++const (
++	cgroupDirectory     = "/sys/fs/cgroup"
++	execDriverDirectory = "/var/run/docker/execdriver"
++)


### PR DESCRIPTION
I've added a build flag for SUSE for builds after 1.5.0 and adjusted the SUSE patch for the 1.5.0 tarball.

@rjschwei, can you take a look?