### PR TITLE
cache: Download directly into cache directory

### DIFF
--- a/ecs-init/cache/cache.go
+++ b/ecs-init/cache/cache.go
@@ -81,7 +81,7 @@ func (d *Downloader) DownloadAgent() error {
 	defer publishedTarballReader.Close()
 
 	md5hash := md5.New()
-	tempFile, err := d.fs.TempFile("", "ecs-agent.tar")
+	tempFile, err := d.fs.TempFile(config.CacheDirectory(), "ecs-agent.tar")
 	if err != nil {
 		return err
 	}

--- a/ecs-init/cache/cache_test.go
+++ b/ecs-init/cache/cache_test.go
@@ -220,7 +220,7 @@ func TestDownloadAgentTempFile(t *testing.T) {
 	mockGetter.EXPECT().Get(config.AgentRemoteTarballMD5()).Return(md5response, nil)
 	mockFS.EXPECT().ReadAll(md5response.Body).Return([]byte(md5sum), nil)
 	mockGetter.EXPECT().Get(config.AgentRemoteTarball()).Return(tarballResponse, nil)
-	mockFS.EXPECT().TempFile("", "ecs-agent.tar").Return(nil, errors.New("test error"))
+	mockFS.EXPECT().TempFile(config.CacheDirectory(), "ecs-agent.tar").Return(nil, errors.New("test error"))
 
 	d := &Downloader{
 		getter: mockGetter,
@@ -252,7 +252,7 @@ func TestDownloadAgentCopyFailure(t *testing.T) {
 		t.Fail()
 	}
 	defer tempfile.Close()
-	mockFS.EXPECT().TempFile("", "ecs-agent.tar").Return(tempfile, nil)
+	mockFS.EXPECT().TempFile(config.CacheDirectory(), "ecs-agent.tar").Return(tempfile, nil)
 	mockFS.EXPECT().TeeReader(tarballResponse.Body, gomock.Any())
 	mockFS.EXPECT().Copy(tempfile, gomock.Any()).Return(int64(0), errors.New("test error"))
 	mockFS.EXPECT().Remove(tempfile.Name())
@@ -287,7 +287,7 @@ func TestDownloadAgentMD5Mismatch(t *testing.T) {
 		t.Fail()
 	}
 	defer tempfile.Close()
-	mockFS.EXPECT().TempFile("", "ecs-agent.tar").Return(tempfile, nil)
+	mockFS.EXPECT().TempFile(config.CacheDirectory(), "ecs-agent.tar").Return(tempfile, nil)
 	mockFS.EXPECT().TeeReader(tarballResponse.Body, gomock.Any())
 	mockFS.EXPECT().Copy(tempfile, gomock.Any()).Return(int64(0), nil)
 	mockFS.EXPECT().Remove(tempfile.Name())
@@ -323,7 +323,7 @@ func TestDownloadAgentSuccess(t *testing.T) {
 		t.Fail()
 	}
 	defer tempfile.Close()
-	mockFS.EXPECT().TempFile("", "ecs-agent.tar").Return(tempfile, nil)
+	mockFS.EXPECT().TempFile(config.CacheDirectory(), "ecs-agent.tar").Return(tempfile, nil)
 	mockFS.EXPECT().TeeReader(tarballResponse.Body, gomock.Any()).Do(func(reader io.Reader, writer io.Writer) {
 		_, err = io.Copy(writer, reader)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/aws/amazon-ecs-agent/issues/420

Download the agent tarball directly into the cache directory such that there are no problems renaming the temporary download file into the final tarball name.

r? @aaithal @juanrhenals @richardpen 