### PR TITLE
Enable Task IAM Role for containers launched with 'host' network mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /x86_64/
 /sources.tar
 /ecs-init-*
+*.swp

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -138,13 +138,14 @@ func (c *Client) getContainerConfig() *godocker.Config {
 
 	// default environment variables
 	envVariables := map[string]string{
-		"ECS_LOGFILE":                   logDir + "/" + config.AgentLogFile,
-		"ECS_DATADIR":                   dataDir,
-		"ECS_AGENT_CONFIG_FILE_PATH":    config.AgentJSONConfigFile(),
-		"ECS_UPDATE_DOWNLOAD_DIR":       config.CacheDirectory(),
-		"ECS_UPDATES_ENABLED":           "true",
-		"ECS_AVAILABLE_LOGGING_DRIVERS": `["json-file","syslog","awslogs"]`,
-		"ECS_ENABLE_TASK_IAM_ROLE":      "true",
+		"ECS_LOGFILE":                           logDir + "/" + config.AgentLogFile,
+		"ECS_DATADIR":                           dataDir,
+		"ECS_AGENT_CONFIG_FILE_PATH":            config.AgentJSONConfigFile(),
+		"ECS_UPDATE_DOWNLOAD_DIR":               config.CacheDirectory(),
+		"ECS_UPDATES_ENABLED":                   "true",
+		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs"]`,
+		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
+		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 	}
 
 	// merge in user-supplied environment variables

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -226,6 +226,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_UPDATES_ENABLED=true", envVariables, t)
 	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"]`, envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
+	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
 
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)


### PR DESCRIPTION
#### Commits
##### Add OUTPUT rule for credentials endpoint.
Modify netfilter Create and Remove functions to add and remove
an OUTPUT rule to redirect processes/containers that use
host's network stack to redirect credentials requests to
localhost:51679.
This is needed for ensuring that containers launched with
net=host can still talk to the credentials endpoint.
##### Set ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true for ECS Agent.
Set the ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST env var config to true
when starting the ECS Agent. This config registers the ECS Agent with
the capability to run Tasks that require Task IAM Roles when
created with 'host' network mode.

#### Testing
 - [x] `make test` passed
 - [x] Manually tested `pre-stop`
```bash
$ sudo iptables -t nat -S > pre-pre-start && sudo ./amazon-ecs-init pre-start && sudo iptables -t nat -S > post-pre-start && diff pre-pre-start post-pre-start
6a7
> -A PREROUTING -d 169.254.170.2/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
7a9
> -A OUTPUT -d 169.254.170.2/32 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
```
 - [x] Manually tested `post-stop`
```bash
$ sudo iptables -t nat -S > pre-post-stop && sudo ./amazon-ecs-init post-stop && sudo iptables -t nat -S > post-post-stop && diff pre-post-stop post-post-stop
2016-08-02T21:10:41Z [INFO] post-stop
2016-08-02T21:10:41Z [INFO] Cleaning up the credentials endpoint setup for Amazon EC2 Container Service Agent
7d6
< -A PREROUTING -d 169.254.170.2/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
9d7
< -A OUTPUT -d 169.254.170.2/32 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
```
 - [x] Manually ran a task with IAM Role and host networking mode and ensured that it was able to retrieve credentials

r? @samuelkarp @juanrhenals @richardpen 