### PR TITLE
CAP_NET_ADMIN for amazon-ecs-agent

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -53,6 +53,10 @@ const (
 	// maxRetries specifies the maximum number of retries for ping to return
 	// a successful response from the docker socket
 	maxRetries = 5
+	// CAP_NET_ADMIN to start agent
+	// For more information on capabilities, please read this manpage:
+	// http://man7.org/linux/man-pages/man7/capabilities.7.html
+	CAP_NET_ADMIN = "NET_ADMIN"
 )
 
 // Client enables business logic for running the Agent inside Docker
@@ -228,6 +232,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		Binds:       binds,
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
+		CapAdd:      []string{CAP_NET_ADMIN},
 	}
 }
 

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -53,10 +53,10 @@ const (
 	// maxRetries specifies the maximum number of retries for ping to return
 	// a successful response from the docker socket
 	maxRetries = 5
-	// CAP_NET_ADMIN to start agent
+	// CapNetAdmin to start agent with NET_ADMIN capability
 	// For more information on capabilities, please read this manpage:
 	// http://man7.org/linux/man-pages/man7/capabilities.7.html
-	CAP_NET_ADMIN = "NET_ADMIN"
+	CapNetAdmin = "NET_ADMIN"
 )
 
 // Client enables business logic for running the Agent inside Docker
@@ -232,7 +232,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		Binds:       binds,
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
-		CapAdd:      []string{CAP_NET_ADMIN},
+		CapAdd:      []string{CapNetAdmin},
 	}
 }
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -258,8 +258,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 		t.Error("Mismatch detected in added host config capabilities")
 	}
 
-	if hostCfg.CapAdd[0] != CAP_NET_ADMIN {
-		t.Errorf("Missing %s from host config capabilities", CAP_NET_ADMIN)
+	if hostCfg.CapAdd[0] != CapNetAdmin {
+		t.Errorf("Missing %s from host config capabilities", CapNetAdmin)
 	}
 }
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -253,6 +253,14 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	if hostCfg.NetworkMode != networkMode {
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)
 	}
+
+	if len(hostCfg.CapAdd) != 1 {
+		t.Error("Mismatch detected in added host config capabilities")
+	}
+
+	if hostCfg.CapAdd[0] != CAP_NET_ADMIN {
+		t.Errorf("Missing %s from host config capabilities", CAP_NET_ADMIN)
+	}
 }
 
 func expectKey(key string, input map[string]struct{}, t *testing.T) {


### PR DESCRIPTION
Adding `CAP_NET_ADMIN` for amazon-ecs-agent

Testing

- [x] make static
- [x] make gotest