### PR TITLE
Mount /proc for agent

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -29,6 +29,9 @@ const (
 	AgentLogFile = "ecs-agent.log"
 
 	UnixSocketPrefix = "unix://"
+
+	// Used to mount /proc for agent container
+	ProcFS = "/proc"
 )
 
 // AgentConfigDirectory returns the location on disk for configuration

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	logDir   = "/log"
-	dataDir  = "/data"
-	readOnly = ":ro"
+	logDir      = "/log"
+	dataDir     = "/data"
+	readOnly    = ":ro"
+	hostProcDir = "/host/proc"
 	// set default to /var/run instead of /var/run/docker.sock in case
 	// /var/run/docker.sock is deleted and recreated outside the container
 	defaultDockerEndpoint = "/var/run"
@@ -227,6 +228,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		config.AgentDataDirectory() + ":" + dataDir,
 		config.AgentConfigDirectory() + ":" + config.AgentConfigDirectory(),
 		config.CacheDirectory() + ":" + config.CacheDirectory(),
+		config.ProcFS + ":" + hostProcDir,
 	}
 	return &godocker.HostConfig{
 		Binds:       binds,

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -236,8 +236,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 
 	hostCfg := opts.HostConfig
 
-	if len(hostCfg.Binds) != 5 {
-		t.Errorf("Expected exactly 5 elements to be in Binds, but was %d", len(hostCfg.Binds))
+	if len(hostCfg.Binds) != 6 {
+		t.Errorf("Expected exactly 6 elements to be in Binds, but was %d", len(hostCfg.Binds))
 	}
 	binds := make(map[string]struct{})
 	for _, binding := range hostCfg.Binds {
@@ -249,6 +249,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentDataDirectory()+":/data", binds, t)
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
+	expectKey(config.ProcFS+":"+hostProcDir, binds, t)
 
 	if hostCfg.NetworkMode != networkMode {
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)


### PR DESCRIPTION
Mount `/proc` 

**Description**
With task-enis, the ECS agent needs access to the container's
network namespace and for this; the agent needs access to the host procfs. This
patch mounts the host `/proc` as `/host/proc` within the agent container.

**Testing**
```
"HostConfig": {
            "Binds": [
                "/var/run:/var/run",
                "/var/log/ecs:/log",
                "/var/lib/ecs/data:/data",
                "/etc/ecs:/etc/ecs",
                "/var/cache/ecs:/var/cache/ecs",
                "/proc:/host/proc"
            ],


"Mounts": [
        ….     
	     {
                "Source": "/proc",
                "Destination": "/host/proc",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
	     },
	….
 ],
```