### PR TITLE
ubuntu trusty: Updated to Go 1.7

### DIFF
--- a/packaging/ubuntu-trusty/debian/README.source
+++ b/packaging/ubuntu-trusty/debian/README.source
@@ -1,0 +1,7 @@
+This package requires Go 1.7 which is only availible for Ubuntu Trusty from PPA.
+
+  * Install Go 1.7 (golang-1.7) from ppa:gophers/archive, see
+    https://launchpad.net/%7Egophers/+archive/ubuntu/archive?field.series_filter=trusty
+
+      add-apt-repository ppa:gophers/archive
+      apt-get install golang-1.7

--- a/packaging/ubuntu-trusty/debian/changelog
+++ b/packaging/ubuntu-trusty/debian/changelog
@@ -1,5 +1,6 @@
 amazon-ecs-init (1.14.3-1) trusty; urgency=low
 
   * Initial release
+    Requires Go 1.7 (golang-1.7) from ppa see README.source
 
  -- Samuel Karp <skarp@amazon.com>  Wed, 22 Feb 2017 10:03:16 +0000

--- a/packaging/ubuntu-trusty/debian/changelog
+++ b/packaging/ubuntu-trusty/debian/changelog
@@ -1,4 +1,4 @@
-amazon-ecs-init (1.14.0-2) trusty; urgency=low
+amazon-ecs-init (1.14.3-1) trusty; urgency=low
 
   * Initial release
 

--- a/packaging/ubuntu-trusty/debian/control
+++ b/packaging/ubuntu-trusty/debian/control
@@ -2,7 +2,7 @@ Source: amazon-ecs-init
 Section: misc
 Priority: optional
 Maintainer: Samuel Karp <skarp@amazon.com>
-Build-Depends: debhelper (>= 9.0.0), golang-1.6 (>= 1.6)
+Build-Depends: debhelper (>= 9.0.0), golang-1.7 (>= 1.7)
 Standards-Version: 3.9.5
 Homepage: https://aws.amazon.com/ecs
 Vcs-Git: git://github.com/aws/amazon-ecs-init.git

--- a/packaging/ubuntu-trusty/debian/rules
+++ b/packaging/ubuntu-trusty/debian/rules
@@ -8,7 +8,7 @@ export DH_VERBOSE=1
 	dh $@
 
 build:
-	PATH=/usr/lib/go-1.6/bin:$(PATH) ./scripts/gobuild.sh ubuntu
+	PATH=/usr/lib/go-1.7/bin:$(PATH) ./scripts/gobuild.sh ubuntu
 
 clean:
 	dh $@


### PR DESCRIPTION
Also bumped version to 1.4.2-2

Requires PPA version of Go since 1.6 is the latest for Trusty. ~~For example [this](https://launchpad.net/~jonathonf/+archive/ubuntu/golang?field.series_filter=trusty).~~ [Go 1.X packages](https://launchpad.net/%7Egophers/+archive/ubuntu/archive?field.series_filter=trusty)  from The Go Language Gophers” team.