### PR TITLE
Reenabled Lint script

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,8 +13,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-set -o verbose
-
 export PATH="${GOPATH//://bin:}/bin:$PATH"
 
 find ecs-init -name "*.go" ! -path "*/vendor/*" ! -name "*_mock_test.go" | xargs -n 1 golint -min_confidence 0.3

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,9 +13,8 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-exit
-# golint disabled until we switch to Go 1.5.  Recent versions of golint require
-# Go >= 1.5, see https://github.com/golang/lint
+set -o verbose
+
 export PATH="${GOPATH//://bin:}/bin:$PATH"
 
-find ecs-init -name "*.go" ! -path "*/Godeps/_workspace/*" ! -name "*_mock_test.go" | xargs -n 1 golint -min_confidence 0.3
+find ecs-init -name "*.go" ! -path "*/vendor/*" ! -name "*_mock_test.go" | xargs -n 1 golint -min_confidence 0.3


### PR DESCRIPTION
Updated lint script ignore section to use new vendor folder. Enabled script due to increase in go version.