### PR TITLE
ecs-init/docker: start ECS Agent with CAP_SYS_ADMIN

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -57,6 +57,12 @@ const (
 	// For more information on capabilities, please read this manpage:
 	// http://man7.org/linux/man-pages/man7/capabilities.7.html
 	CapNetAdmin = "NET_ADMIN"
+	// CapSysAdmin to start agent with SYS_ADMIN capability
+	// This is needed for the ECS Agent to invoke the setns call when
+	// configuring the network namespace of the pause container
+	// For more information on setns, please read this manpage:
+	// http://man7.org/linux/man-pages/man2/setns.2.html
+	CapSysAdmin = "SYS_ADMIN"
 )
 
 // Client enables business logic for running the Agent inside Docker
@@ -232,7 +238,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		Binds:       binds,
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
-		CapAdd:      []string{CapNetAdmin},
+		CapAdd:      []string{CapNetAdmin, CapSysAdmin},
 	}
 }
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -254,12 +254,25 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)
 	}
 
-	if len(hostCfg.CapAdd) != 1 {
+	if len(hostCfg.CapAdd) != 2 {
 		t.Error("Mismatch detected in added host config capabilities")
 	}
 
-	if hostCfg.CapAdd[0] != CapNetAdmin {
+	capNetAdminFound := false
+	capSysAdminFound := false
+	for _, cap := range hostCfg.CapAdd {
+		if cap == CapNetAdmin {
+			capNetAdminFound = true
+		}
+		if cap == CapSysAdmin {
+			capSysAdminFound = true
+		}
+	}
+	if !capNetAdminFound {
 		t.Errorf("Missing %s from host config capabilities", CapNetAdmin)
+	}
+	if !capSysAdminFound {
+		t.Errorf("Missing %s from host config capabilities", CapSysAdmin)
 	}
 }
 


### PR DESCRIPTION
This is required by the ECS Agent to perform the necessary
network namespace operations, specificall for the setns
call.

## Testing Done 
- [X] `make test`
- [X] `make static`
- [X] Manual testing: Inspected the ECS Agent launched by ECS Init for the presence of capabilities:
```
$ docker inspect  --format='{{.HostConfig.CapAdd}}' ecs-agent
[NET_ADMIN SYS_ADMIN]
```