### PR TITLE
Add a systemd unit file for running ECS Agent

### DIFF
--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -30,7 +30,7 @@ After=docker.service
 WantedBy=multi-user.target
 
 [Service]
-Environment=AGENT_TAG=v1.16.0
+Environment=AGENT_TAG=v1.16.1
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -30,7 +30,7 @@ After=docker.service
 WantedBy=multi-user.target
 
 [Service]
-Environment=AGENT_TAG=v1.16.1
+Environment=AGENT_TAG=v1.16.2
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -27,8 +27,12 @@ Requires=docker.service
 After=docker.service
 
 [Service]
+Environment=AGENT_TAG=v1.15.0
 Type=simple
-ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:latest
+# Load an updated agent, if it exists:
+ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'
+# If we don't have an agent, load from disk, if possible, or Docker Hub:
+ExecStartPre=/bin/sh -c "docker inspect amazon/amazon-ecs-agent || docker load < /var/cache/ecs/ecs-agent.tar || docker pull amazon/amazon-ecs-agent:${AGENT_TAG}"
 ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
 ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 169.254.170.2/32 \
@@ -48,8 +52,9 @@ ExecStart=/usr/bin/docker run --name ecs-agent \
   --env ECS_AVAILABLE_LOGGING_DRIVERS='["json-file","syslog","awslogs"]' \
   --env ECS_ENABLE_TASK_IAM_ROLE=true \
   --env ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
+  --env ECS_UPDATES_ENABLED=true \
   --env-file=/etc/ecs/ecs.config \
-  amazon/amazon-ecs-agent:latest
+  amazon/amazon-ecs-agent:${AGENT_TAG}
 ExecStop=/usr/bin/docker stop ecs-agent
 ExecStopPost=-/sbin/iptables -t nat -D PREROUTING -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -30,7 +30,7 @@ After=docker.service
 WantedBy=multi-user.target
 
 [Service]
-Environment=AGENT_TAG=v1.16.2
+Environment=AGENT_TAG=v1.17.0
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -26,6 +26,9 @@ Documentation=http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_age
 Requires=docker.service
 After=docker.service
 
+[Install]
+WantedBy=multi-user.target
+
 [Service]
 Environment=AGENT_TAG=v1.16.0
 Type=simple

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -27,7 +27,7 @@ Requires=docker.service
 After=docker.service
 
 [Service]
-Environment=AGENT_TAG=v1.15.0
+Environment=AGENT_TAG=v1.16.0
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'
@@ -39,12 +39,21 @@ ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
 ExecStartPre=/sbin/sysctl -w net.ipv4.conf.all.route_localnet=1
 ExecStartPre=-/usr/bin/docker rm ecs-agent
+ExecStartPre=-/bin/mkdir -p /var/lib/ecs/dhclient
 ExecStart=/usr/bin/docker run --name ecs-agent \
+  --init \
   --restart=on-failure:10 \
   --volume=/var/run:/var/run \
   --volume=/var/log/ecs/:/log \
   --volume=/var/lib/ecs/data:/data \
   --volume=/etc/ecs:/etc/ecs \
+  --volume=/sbin:/sbin \
+  --volume=/lib:/lib \
+  --volume=/lib64:/lib64 \
+  --volume=/usr/lib:/usr/lib \
+  --volume=/proc:/host/proc \
+  --volume=/sys/fs/cgroup:/sys/fs/cgroup \
+  --volume=/var/lib/ecs/dhclient:/var/lib/dhclient \
   --net=host \
   --env ECS_LOGFILE=/log/ecs-agent.log \
   --env ECS_DATADIR=/data \
@@ -53,7 +62,10 @@ ExecStart=/usr/bin/docker run --name ecs-agent \
   --env ECS_ENABLE_TASK_IAM_ROLE=true \
   --env ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
   --env ECS_UPDATES_ENABLED=true \
+  --env ECS_ENABLE_TASK_ENI=true \
   --env-file=/etc/ecs/ecs.config \
+  --cap-add=sys_admin \
+  --cap-add=net_admin \
   amazon/amazon-ecs-agent:${AGENT_TAG}
 ExecStop=/usr/bin/docker stop ecs-agent
 ExecStopPost=-/sbin/iptables -t nat -D PREROUTING -d 169.254.170.2/32 \

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -1,0 +1,61 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+#
+# A systemd unit file to run `ecs-agent` in a Docker container. This service
+# attempts to duplicate the functionality of the `ecs-init` Golang package. The
+# notable differences currently are:
+# 1. The unit file does an unconditional pull of the latest ECS Agent from
+# Docker Hub at startup.
+# 2. The unit file does not currently handle the Agent's self-upgrade
+# functionality.
+
+[Unit]
+Description=Amazon ECS Agent
+Documentation=http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_agent.html
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:latest
+ExecStartPre=/sbin/iptables -t nat -A PREROUTING -d 169.254.170.2/32 \
+ -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 169.254.170.2/32 \
+ -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+ExecStartPre=/sbin/sysctl -w net.ipv4.conf.all.route_localnet=1
+ExecStartPre=-/usr/bin/docker rm ecs-agent
+ExecStart=/usr/bin/docker run --name ecs-agent \
+  --restart=on-failure:10 \
+  --volume=/var/run:/var/run \
+  --volume=/var/log/ecs/:/log \
+  --volume=/var/lib/ecs/data:/data \
+  --volume=/etc/ecs:/etc/ecs \
+  --net=host \
+  --env ECS_LOGFILE=/log/ecs-agent.log \
+  --env ECS_DATADIR=/data \
+  --env ECS_UPDATES_ENABLED=false \
+  --env ECS_AVAILABLE_LOGGING_DRIVERS='["json-file","syslog","awslogs"]' \
+  --env ECS_ENABLE_TASK_IAM_ROLE=true \
+  --env ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
+  --env-file=/etc/ecs/ecs.config \
+  amazon/amazon-ecs-agent:latest
+ExecStop=/usr/bin/docker stop ecs-agent
+ExecStopPost=-/sbin/iptables -t nat -D PREROUTING -d 169.254.170.2/32 \
+ -p tcp -m tcp --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+ExecStopPost=-/sbin/iptables -t nat -D OUTPUT -d 169.254.170.2/32 \
+ -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+ExecStopPost=/bin/sh -c \
+ "/sbin/sysctl -w net.ipv4.conf.all.route_localnet=$(/sbin/sysctl -q -n net.ipv4.conf.default.route_localnet)"
+Restart=on-failure
+RestartPreventExitStatus=5

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -30,7 +30,7 @@ After=docker.service
 WantedBy=multi-user.target
 
 [Service]
-Environment=AGENT_TAG=v1.17.0
+Environment=AGENT_TAG=v1.17.2
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'

--- a/integration/systemd/ecs-agent.service
+++ b/integration/systemd/ecs-agent.service
@@ -30,7 +30,7 @@ After=docker.service
 WantedBy=multi-user.target
 
 [Service]
-Environment=AGENT_TAG=v1.17.2
+Environment=AGENT_TAG=v1.30.0
 Type=simple
 # Load an updated agent, if it exists:
 ExecStartPre=-/bin/sh -c 'test -f /var/cache/ecs/desired-image && docker load $(cat /var/cache/ecs/desired-image) && rm -f $(cat /var/cache/ecs/desired-image) /var/cache/ecs/desired-image'
@@ -42,7 +42,6 @@ ExecStartPre=/sbin/iptables -t nat -A OUTPUT -d 169.254.170.2/32 \
  -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
 ExecStartPre=/sbin/sysctl -w net.ipv4.conf.all.route_localnet=1
 ExecStartPre=-/usr/bin/docker rm ecs-agent
-ExecStartPre=-/bin/mkdir -p /var/lib/ecs/dhclient
 ExecStart=/usr/bin/docker run --name ecs-agent \
   --init \
   --restart=on-failure:10 \
@@ -50,13 +49,8 @@ ExecStart=/usr/bin/docker run --name ecs-agent \
   --volume=/var/log/ecs/:/log \
   --volume=/var/lib/ecs/data:/data \
   --volume=/etc/ecs:/etc/ecs \
-  --volume=/sbin:/sbin \
-  --volume=/lib:/lib \
-  --volume=/lib64:/lib64 \
-  --volume=/usr/lib:/usr/lib \
   --volume=/proc:/host/proc \
   --volume=/sys/fs/cgroup:/sys/fs/cgroup \
-  --volume=/var/lib/ecs/dhclient:/var/lib/dhclient \
   --net=host \
   --env ECS_LOGFILE=/log/ecs-agent.log \
   --env ECS_DATADIR=/data \

--- a/integration/systemd/load-and-verify-agent.sh
+++ b/integration/systemd/load-and-verify-agent.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+# 
+#     http://aws.amazon.com/apache2.0/
+# 
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This wrapper script ensures that we've loaded the desired ECS agent
+# and have attached the "latest" tag to it.
+# USAGE: load-and-verify-agent.sh DEFAULT_TAG
+
+docker ping > /dev/null || {
+    echo "Cannot talk to Docker daemon. Aborting." >&2
+    exit 1
+}
+
+DEFAULT_TAG=$1 ; shift
+AGENT_IMAGE_NAME=amazon/amazon-ecs-agent
+DESIRED_IMAGE_FILE=/var/cache/ecs/desired-image
+
+if [ -f "$DESIRED_IMAGE_FILE" ]; then
+    DESIRED_TAG=$(head -n1 "$DESIRED_IMAGE_FILE")
+else
+    DESIRED_TAG="$DEFAULT_TAG"
+fi
+
+IMAGE_NAME="${AGENT_IMAGE_NAME}:${DESIRED_TAG}"
+
+
+image_id=$(docker inspect "$IMAGE_NAME")
+latest_image_id=$(docker inspect "${AGENT_IMAGE_NAME}:latest")
+
+if -z "$image_id" ; then
+    # We already have the desired image. Ensure that "latest" points to it.
+    docker tag ${AGENT_IMAGE_NAME}:${image_id##sha256:} ${AGENT_IMAGE_NAME}:latest
+    


### PR DESCRIPTION
This change introduces a systemd unit file that configures and runs the agent in much the same way as the golang ecs-init code. It is intended to be used in place ecs-init on systemd-based systems, although it is not currently a complete replacement for init.

 * The unit file does an unconditional pull of the latest ECS Agent from Docker Hub at startup. Neither the "unconditional" part nor the "Docker Hub" part are desirable.
 * The unit file does not currently handle the Agent's self-upgrade functionality. It may require changes to the agent's behavior in order to properly support this here.

The unit file is stored in a new "integration" subdirectory as there didn't seem to be a better place to store it. In theory this directory can contain additional configuration or scripts to handle integration with other systems if people want to add support for e.g. `runit` or `openrc`.

I have tested this on both Debian 9 (stretch) and Fedora 25. It works without modification on both.