### PR TITLE
Start agent with task eni enabled flag

### DIFF
--- a/ecs-init/Godeps/Godeps.json
+++ b/ecs-init/Godeps/Godeps.json
@@ -305,7 +305,8 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Rev": "c933ed18bef34ec2955de03de8ef9a3bb996e3df"
+			"Comment": "docker-1.9/go-1.4-421-g98edf3e",
+			"Rev": "98edf3edfae6a6500fecc69d2bcccf1302544004"
 		},
 		{
 			"ImportPath": "github.com/go-ini/ini",

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -76,6 +76,12 @@ func AgentDataDirectory() string {
 	return directoryPrefix + "/var/lib/ecs/data"
 }
 
+// AgentDHClientLeasesDirectory returns the location on disk where dhclient
+// leases information is tracked for ENIs attached to tasks
+func AgentDHClientLeasesDirectory() string {
+	return directoryPrefix + "/var/lib/ecs/dhclient"
+}
+
 // CacheDirectory returns the location on disk where Agent images should be cached
 func CacheDirectory() string {
 	return directoryPrefix + "/var/cache/ecs"

--- a/ecs-init/docker/dependencies.go
+++ b/ecs-init/docker/dependencies.go
@@ -28,6 +28,12 @@ import (
 	godocker "github.com/fsouza/go-dockerclient"
 )
 
+const (
+	// dockerClientAPIVersion specifies the minimum docker client API version
+	// required by ECS Init
+	dockerClientAPIVersion = "1.15"
+)
+
 type dockerclient interface {
 	ListImages(opts godocker.ListImagesOptions) ([]godocker.APIImages, error)
 	LoadImage(opts godocker.LoadImageOptions) error
@@ -60,7 +66,7 @@ func newDockerClient(dockerClientFactory dockerClientFactory, pingBackoff backof
 		dockerUnixSocketSourcePath = "/var/run/docker.sock"
 	}
 	client, err := dockerClientFactory.NewVersionedClient(
-		config.UnixSocketPrefix+dockerUnixSocketSourcePath, "1.15")
+		config.UnixSocketPrefix+dockerUnixSocketSourcePath, dockerClientAPIVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/ecs-init/docker/dependencies.go
+++ b/ecs-init/docker/dependencies.go
@@ -31,7 +31,10 @@ import (
 const (
 	// dockerClientAPIVersion specifies the minimum docker client API version
 	// required by ECS Init
-	dockerClientAPIVersion = "1.15"
+	// Version 1.25 is required for setting Init to true when constructing
+	// the HostConfig for creating the ECS Agent to enable the Task
+	// Networking with ENI capability
+	dockerClientAPIVersion = "1.25"
 )
 
 type dockerclient interface {

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -262,6 +262,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
 		CapAdd:      []string{CapNetAdmin, CapSysAdmin},
+		Init:        true,
 	}
 }
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -277,6 +277,10 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	if !capSysAdminFound {
 		t.Errorf("Missing %s from host config capabilities", CapSysAdmin)
 	}
+
+	if hostCfg.Init != true {
+		t.Error("Incorrect host config. Expected Init to be true")
+	}
 }
 
 func expectKey(key string, input map[string]struct{}, t *testing.T) {

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -227,6 +227,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"]`, envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
+	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)
 
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)
@@ -234,8 +235,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 
 	hostCfg := opts.HostConfig
 
-	if len(hostCfg.Binds) != 6 {
-		t.Errorf("Expected exactly 6 elements to be in Binds, but was %d", len(hostCfg.Binds))
+	if len(hostCfg.Binds) != 9 {
+		t.Errorf("Expected exactly 9 elements to be in Binds, but was %d", len(hostCfg.Binds))
 	}
 	binds := make(map[string]struct{})
 	for _, binding := range hostCfg.Binds {
@@ -247,7 +248,10 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentDataDirectory()+":/data", binds, t)
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
-	expectKey(config.ProcFS+":"+hostProcDir, binds, t)
+	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
+	expectKey(config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation, binds, t)
+	expectKey(dhclientLibDir+":"+dhclientLibDir+":ro", binds, t)
+	expectKey(dhclientExecutableDir+":"+dhclientExecutableDir+":ro", binds, t)
 
 	if hostCfg.NetworkMode != networkMode {
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/.travis.yml
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/.travis.yml
@@ -1,18 +1,18 @@
 language: go
 sudo: required
 go:
-  - 1.7.x
   - 1.8.x
+  - 1.9
   - tip
 os:
   - linux
   - osx
 env:
   matrix:
-    - GOARCH=amd64 DOCKER_VERSION=1.12.6
-    - GOARCH=386   DOCKER_VERSION=1.12.6
-    - GOARCH=amd64 DOCKER_VERSION=1.13.1
-    - GOARCH=386   DOCKER_VERSION=1.13.1
+    - GOARCH=amd64 DOCKER_PKG_VERSION=17.06.0~ce-0~ubuntu
+    - GOARCH=386   DOCKER_PKG_VERSION=17.06.0~ce-0~ubuntu
+    - GOARCH=amd64 DOCKER_PKG_VERSION=17.05.0~ce-0~ubuntu-trusty
+    - GOARCH=386   DOCKER_PKG_VERSION=17.05.0~ce-0~ubuntu-trusty
   global:
     - GO_TEST_FLAGS=-race
     - DOCKER_HOST=tcp://127.0.0.1:2375
@@ -27,6 +27,6 @@ matrix:
   fast_finish: true
   exclude:
     - os: osx
-      env: GOARCH=amd64 DOCKER_VERSION=1.12.6
+      env: GOARCH=amd64 DOCKER_PKG_VERSION=17.05.0~ce-0~ubuntu-trusty
     - os: osx
-      env: GOARCH=386   DOCKER_VERSION=1.12.6
+      env: GOARCH=386   DOCKER_PKG_VERSION=17.05.0~ce-0~ubuntu-trusty

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/AUTHORS
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/AUTHORS
@@ -36,7 +36,10 @@ Changping Chen
 Cheah Chu Yeow
 cheneydeng
 Chris Bednarski
+Chris Stavropoulos
 Christian Stewart
+Christophe Mourette
+Clint Armstrong
 CMGS
 Colin Hebert
 Craig Jellick
@@ -45,16 +48,19 @@ Dan Williams
 Daniel, Dao Quang Minh
 Daniel Garcia
 Daniel Hiltgen
+Daniel Tsui
 Darren Shepherd
 Dave Choi
 David Huie
 Dawn Chen
+Derek Petersen
 Dinesh Subhraveti
 Drew Wells
 Ed
 Elias G. Schneevoigt
 Erez Horev
 Eric Anderson
+Eric J. Holmes
 Eric Mountain
 Erwin van Eyk
 Ethan Mosbaugh
@@ -75,6 +81,7 @@ He Simei
 Ivan Mikushin
 James Bardin
 James Nugent
+Jamie Snell
 Januar Wayong
 Jari Kolehmainen
 Jason Wilder
@@ -86,6 +93,7 @@ Jen Andre
 Jérôme Laurens
 Jim Minter
 Johan Euphrosine
+Johannes Scheuermann
 John Hughes
 Jorge Marey
 Julian Einwag

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/README.markdown
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/README.markdown
@@ -110,3 +110,16 @@ Commited code must pass:
 Running `make test` will check all of these. If your editor does not
 automatically call ``gofmt -s``, `make fmt` will format all go files in this
 repository.
+
+## Using with Docker 1.9 and Go 1.4
+
+There's a tag for using go-dockerclient with Docker 1.9 (which requires
+compiling go-dockerclient with Go 1.4), the tag name is ``docker-1.9/go-1.4``.
+
+The instructions below can be used to get a version of go-dockerclient that compiles with Go 1.4:
+
+```
+% git clone -b docker-1.9/go-1.4 https://github.com/fsouza/go-dockerclient.git $GOPATH/src/github.com/fsouza/go-dockerclient
+% git clone -b v1.9.1 https://github.com/docker/docker.git $GOPATH/src/github.com/docker/docker
+% go get github.com/fsouza/go-dockerclient
+```

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/appveyor.yml
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/appveyor.yml
@@ -5,16 +5,16 @@ clone_folder: c:\gopath\src\github.com\fsouza\go-dockerclient
 environment:
   GOPATH: c:\gopath
   matrix:
-    - GOVERSION: 1.7.5
-    - GOVERSION: 1.8.1
+    - GOVERSION: 1.8.3
+    - GOVERSION: 1.9
 install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - rmdir c:\go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
   - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
 build_script:
-  - go get -d -t ./...
+  - go get -race -d -t ./...
 test_script:
-  - go test -v ./...
+  - go test -race ./...
 matrix:
   fast_finish: true

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/client_unix.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/client_unix.go
@@ -10,8 +10,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 // initializeNativeClient initializes the native Unix domain socket client on
@@ -21,9 +19,9 @@ func (c *Client) initializeNativeClient() {
 		return
 	}
 	socketPath := c.endpointURL.Path
-	tr := cleanhttp.DefaultTransport()
+	tr := defaultTransport()
 	tr.Dial = func(network, addr string) (net.Conn, error) {
-		return c.Dialer.Dial(network, addr)
+		return c.Dialer.Dial(unixProtocol, socketPath)
 	}
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return c.Dialer.Dial(unixProtocol, socketPath)

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/client_windows.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/client_windows.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 const namedPipeConnectTimeout = 2 * time.Second
@@ -36,7 +35,7 @@ func (c *Client) initializeNativeClient() {
 		timeout := namedPipeConnectTimeout
 		return winio.DialPipe(namedPipePath, &timeout)
 	}
-	tr := cleanhttp.DefaultTransport()
+	tr := defaultTransport()
 	tr.Dial = dialFunc
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return dialFunc(network, addr)

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/container.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/container.go
@@ -204,7 +204,7 @@ func (s *State) StateString() string {
 // PortBinding represents the host/container port mapping as returned in the
 // `docker inspect` json
 type PortBinding struct {
-	HostIP   string `json:"HostIP,omitempty" yaml:"HostIP,omitempty" toml:"HostIP,omitempty"`
+	HostIP   string `json:"HostIp,omitempty" yaml:"HostIp,omitempty" toml:"HostIp,omitempty"`
 	HostPort string `json:"HostPort,omitempty" yaml:"HostPort,omitempty" toml:"HostPort,omitempty"`
 }
 
@@ -326,6 +326,43 @@ type Config struct {
 	// This is no longer used and has been kept here for backward
 	// compatibility, please use HostConfig.VolumesFrom.
 	VolumesFrom string `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty" toml:"VolumesFrom,omitempty"`
+}
+
+// HostMount represents a mount point in the container in HostConfig.
+//
+// It has been added in the version 1.25 of the Docker API
+type HostMount struct {
+	Target        string         `json:"Target,omitempty" yaml:"Target,omitempty" toml:"Target,omitempty"`
+	Source        string         `json:"Source,omitempty" yaml:"Source,omitempty" toml:"Source,omitempty"`
+	Type          string         `json:"Type,omitempty" yaml:"Type,omitempty" toml:"Type,omitempty"`
+	ReadOnly      bool           `json:"ReadOnly,omitempty" yaml:"ReadOnly,omitempty" toml:"ReadOnly,omitempty"`
+	BindOptions   *BindOptions   `json:"BindOptions,omitempty" yaml:"BindOptions,omitempty" toml:"BindOptions,omitempty"`
+	VolumeOptions *VolumeOptions `json:"VolumeOptions,omitempty" yaml:"VolumeOptions,omitempty" toml:"VolumeOptions,omitempty"`
+	TempfsOptions *TempfsOptions `json:"TempfsOptions,omitempty" yaml:"TempfsOptions,omitempty" toml:"TempfsOptions,omitempty"`
+}
+
+// BindOptions contains optional configuration for the bind type
+type BindOptions struct {
+	Propagation string `json:"Propagation,omitempty" yaml:"Propagation,omitempty" toml:"Propagation,omitempty"`
+}
+
+// VolumeOptions contains optional configuration for the volume type
+type VolumeOptions struct {
+	NoCopy       bool               `json:"NoCopy,omitempty" yaml:"NoCopy,omitempty" toml:"NoCopy,omitempty"`
+	Labels       map[string]string  `json:"Labels,omitempty" yaml:"Labels,omitempty" toml:"Labels,omitempty"`
+	DriverConfig VolumeDriverConfig `json:"DriverConfig,omitempty" yaml:"DriverConfig,omitempty" toml:"DriverConfig,omitempty"`
+}
+
+// TempfsOptions contains optional configuration for the tempfs type
+type TempfsOptions struct {
+	SizeBytes int64 `json:"SizeBytes,omitempty" yaml:"SizeBytes,omitempty" toml:"SizeBytes,omitempty"`
+	Mode      int   `json:"Mode,omitempty" yaml:"Mode,omitempty" toml:"Mode,omitempty"`
+}
+
+// VolumeDriverConfig holds a map of volume driver specific options
+type VolumeDriverConfig struct {
+	Name    string            `json:"Name,omitempty" yaml:"Name,omitempty" toml:"Name,omitempty"`
+	Options map[string]string `json:"Options,omitempty" yaml:"Options,omitempty" toml:"Options,omitempty"`
 }
 
 // Mount represents a mount point in the container.
@@ -736,6 +773,12 @@ type HostConfig struct {
 	AutoRemove           bool                   `json:"AutoRemove,omitempty" yaml:"AutoRemove,omitempty" toml:"AutoRemove,omitempty"`
 	StorageOpt           map[string]string      `json:"StorageOpt,omitempty" yaml:"StorageOpt,omitempty" toml:"StorageOpt,omitempty"`
 	Sysctls              map[string]string      `json:"Sysctls,omitempty" yaml:"Sysctls,omitempty" toml:"Sysctls,omitempty"`
+	CPUCount             int64                  `json:"CpuCount,omitempty" yaml:"CpuCount,omitempty"`
+	CPUPercent           int64                  `json:"CpuPercent,omitempty" yaml:"CpuPercent,omitempty"`
+	IOMaximumBandwidth   int64                  `json:"IOMaximumBandwidth,omitempty" yaml:"IOMaximumBandwidth,omitempty"`
+	IOMaximumIOps        int64                  `json:"IOMaximumIOps,omitempty" yaml:"IOMaximumIOps,omitempty"`
+	Mounts               []HostMount            `json:"Mounts,omitempty" yaml:"Mounts,omitempty" toml:"Mounts,omitempty"`
+	Init                 bool                   `json:",omitempty" yaml:",omitempty"`
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces
@@ -911,6 +954,8 @@ func (c *Client) TopContainer(id string, psArgs string) (TopResult, error) {
 // See https://goo.gl/Dk3Xio for more details.
 type Stats struct {
 	Read      time.Time `json:"read,omitempty" yaml:"read,omitempty" toml:"read,omitempty"`
+	PreRead   time.Time `json:"preread,omitempty" yaml:"preread,omitempty" toml:"preread,omitempty"`
+	NumProcs  uint32    `json:"num_procs" yaml:"num_procs" toml:"num_procs"`
 	PidsStats struct {
 		Current uint64 `json:"current,omitempty" yaml:"current,omitempty"`
 	} `json:"pids_stats,omitempty" yaml:"pids_stats,omitempty" toml:"pids_stats,omitempty"`
@@ -950,10 +995,13 @@ type Stats struct {
 			HierarchicalMemswLimit  uint64 `json:"hierarchical_memsw_limit,omitempty" yaml:"hierarchical_memsw_limit,omitempty" toml:"hierarchical_memsw_limit,omitempty"`
 			Swap                    uint64 `json:"swap,omitempty" yaml:"swap,omitempty" toml:"swap,omitempty"`
 		} `json:"stats,omitempty" yaml:"stats,omitempty" toml:"stats,omitempty"`
-		MaxUsage uint64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty" toml:"max_usage,omitempty"`
-		Usage    uint64 `json:"usage,omitempty" yaml:"usage,omitempty" toml:"usage,omitempty"`
-		Failcnt  uint64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty" toml:"failcnt,omitempty"`
-		Limit    uint64 `json:"limit,omitempty" yaml:"limit,omitempty" toml:"limit,omitempty"`
+		MaxUsage          uint64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty" toml:"max_usage,omitempty"`
+		Usage             uint64 `json:"usage,omitempty" yaml:"usage,omitempty" toml:"usage,omitempty"`
+		Failcnt           uint64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty" toml:"failcnt,omitempty"`
+		Limit             uint64 `json:"limit,omitempty" yaml:"limit,omitempty" toml:"limit,omitempty"`
+		Commit            uint64 `json:"commitbytes,omitempty" yaml:"commitbytes,omitempty" toml:"privateworkingset,omitempty"`
+		CommitPeak        uint64 `json:"commitpeakbytes,omitempty" yaml:"commitpeakbytes,omitempty" toml:"commitpeakbytes,omitempty"`
+		PrivateWorkingSet uint64 `json:"privateworkingset,omitempty" yaml:"privateworkingset,omitempty" toml:"privateworkingset,omitempty"`
 	} `json:"memory_stats,omitempty" yaml:"memory_stats,omitempty" toml:"memory_stats,omitempty"`
 	BlkioStats struct {
 		IOServiceBytesRecursive []BlkioStatsEntry `json:"io_service_bytes_recursive,omitempty" yaml:"io_service_bytes_recursive,omitempty" toml:"io_service_bytes_recursive,omitempty"`
@@ -965,8 +1013,14 @@ type Stats struct {
 		IOTimeRecursive         []BlkioStatsEntry `json:"io_time_recursive,omitempty" yaml:"io_time_recursive,omitempty" toml:"io_time_recursive,omitempty"`
 		SectorsRecursive        []BlkioStatsEntry `json:"sectors_recursive,omitempty" yaml:"sectors_recursive,omitempty" toml:"sectors_recursive,omitempty"`
 	} `json:"blkio_stats,omitempty" yaml:"blkio_stats,omitempty" toml:"blkio_stats,omitempty"`
-	CPUStats    CPUStats `json:"cpu_stats,omitempty" yaml:"cpu_stats,omitempty" toml:"cpu_stats,omitempty"`
-	PreCPUStats CPUStats `json:"precpu_stats,omitempty"`
+	CPUStats     CPUStats `json:"cpu_stats,omitempty" yaml:"cpu_stats,omitempty" toml:"cpu_stats,omitempty"`
+	PreCPUStats  CPUStats `json:"precpu_stats,omitempty"`
+	StorageStats struct {
+		ReadCountNormalized  uint64 `json:"read_count_normalized,omitempty" yaml:"read_count_normalized,omitempty" toml:"read_count_normalized,omitempty"`
+		ReadSizeBytes        uint64 `json:"read_size_bytes,omitempty" yaml:"read_size_bytes,omitempty" toml:"read_size_bytes,omitempty"`
+		WriteCountNormalized uint64 `json:"write_count_normalized,omitempty" yaml:"write_count_normalized,omitempty" toml:"write_count_normalized,omitempty"`
+		WriteSizeBytes       uint64 `json:"write_size_bytes,omitempty" yaml:"write_size_bytes,omitempty" toml:"write_size_bytes,omitempty"`
+	} `json:"storage_stats,omitempty" yaml:"storage_stats,omitempty" toml:"storage_stats,omitempty"`
 }
 
 // NetworkStats is a stats entry for network stats
@@ -1052,6 +1106,7 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 		}
 	}()
 
+	reqSent := make(chan struct{})
 	go func() {
 		err := c.stream("GET", fmt.Sprintf("/containers/%s/stats?stream=%v", opts.ID, opts.Stream), streamOptions{
 			rawJSONStream:     true,
@@ -1060,6 +1115,7 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 			timeout:           opts.Timeout,
 			inactivityTimeout: opts.InactivityTimeout,
 			context:           opts.Context,
+			reqSent:           reqSent,
 		})
 		if err != nil {
 			dockerError, ok := err.(*Error)
@@ -1090,6 +1146,7 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 
 	decoder := json.NewDecoder(readCloser)
 	stats := new(Stats)
+	<-reqSent
 	for err := decoder.Decode(stats); err != io.EOF; err = decoder.Decode(stats) {
 		if err != nil {
 			return err

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/exec.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/exec.go
@@ -6,6 +6,7 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +30,7 @@ type CreateExecOptions struct {
 	AttachStdout bool            `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty" toml:"AttachStdout,omitempty"`
 	AttachStderr bool            `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty" toml:"AttachStderr,omitempty"`
 	Tty          bool            `json:"Tty,omitempty" yaml:"Tty,omitempty" toml:"Tty,omitempty"`
+	Env          []string        `json:"Env,omitempty" yaml:"Env,omitempty" toml:"Env,omitempty"`
 	Cmd          []string        `json:"Cmd,omitempty" yaml:"Cmd,omitempty" toml:"Cmd,omitempty"`
 	Container    string          `json:"Container,omitempty" yaml:"Container,omitempty" toml:"Container,omitempty"`
 	User         string          `json:"User,omitempty" yaml:"User,omitempty" toml:"User,omitempty"`
@@ -41,6 +43,9 @@ type CreateExecOptions struct {
 //
 // See https://goo.gl/60TeBP for more details
 func (c *Client) CreateExec(opts CreateExecOptions) (*Exec, error) {
+	if len(opts.Env) > 0 && c.serverAPIVersion.LessThan(apiVersion125) {
+		return nil, errors.New("exec configuration Env is only supported in API#1.25 and above")
+	}
 	path := fmt.Sprintf("/containers/%s/exec", opts.Container)
 	resp, err := c.do("POST", path, doOptions{data: opts, context: opts.Context})
 	if err != nil {

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/network.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/network.go
@@ -125,8 +125,9 @@ type CreateNetworkOptions struct {
 //
 // See https://goo.gl/T8kRVH for more details.
 type IPAMOptions struct {
-	Driver string       `json:"Driver" yaml:"Driver" toml:"Driver"`
-	Config []IPAMConfig `json:"Config" yaml:"Config" toml:"Config"`
+	Driver  string            `json:"Driver" yaml:"Driver" toml:"Driver"`
+	Config  []IPAMConfig      `json:"Config" yaml:"Config" toml:"Config"`
+	Options map[string]string `json:"Options" yaml:"Options" toml:"Options"`
 }
 
 // IPAMConfig represents IPAM configurations

--- a/ecs-init/vendor/github.com/fsouza/go-dockerclient/service.go
+++ b/ecs-init/vendor/github.com/fsouza/go-dockerclient/service.go
@@ -6,9 +6,11 @@ package docker
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
@@ -166,4 +168,49 @@ func (c *Client) ListServices(opts ListServicesOptions) ([]swarm.Service, error)
 		return nil, err
 	}
 	return services, nil
+}
+
+// LogsServiceOptions represents the set of options used when getting logs from a
+// service.
+type LogsServiceOptions struct {
+	Context           context.Context
+	Service           string        `qs:"-"`
+	OutputStream      io.Writer     `qs:"-"`
+	ErrorStream       io.Writer     `qs:"-"`
+	InactivityTimeout time.Duration `qs:"-"`
+	Tail              string
+
+	// Use raw terminal? Usually true when the container contains a TTY.
+	RawTerminal bool `qs:"-"`
+	Since       int64
+	Follow      bool
+	Stdout      bool
+	Stderr      bool
+	Timestamps  bool
+	Details     bool
+}
+
+// GetServiceLogs gets stdout and stderr logs from the specified service.
+//
+// When LogsServiceOptions.RawTerminal is set to false, go-dockerclient will multiplex
+// the streams and send the containers stdout to LogsServiceOptions.OutputStream, and
+// stderr to LogsServiceOptions.ErrorStream.
+//
+// When LogsServiceOptions.RawTerminal is true, callers will get the raw stream on
+// LogsServiceOptions.OutputStream.
+func (c *Client) GetServiceLogs(opts LogsServiceOptions) error {
+	if opts.Service == "" {
+		return &NoSuchService{ID: opts.Service}
+	}
+	if opts.Tail == "" {
+		opts.Tail = "all"
+	}
+	path := "/services/" + opts.Service + "/logs?" + queryString(opts)
+	return c.stream("GET", path, streamOptions{
+		setRawTerminal:    opts.RawTerminal,
+		stdout:            opts.OutputStream,
+		stderr:            opts.ErrorStream,
+		inactivityTimeout: opts.InactivityTimeout,
+		context:           opts.Context,
+	})
 }

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -31,7 +31,7 @@ Requires:       docker >= 1.6.0, docker <= 17.03.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps
-Requires(post): docker >= 1.6.0
+Requires:       dhclient
 
 Provides:       bundled(docker)
 Provides:       bundled(golang(github.com/docker/docker/pkg/archive))
@@ -53,6 +53,7 @@ Provides:       bundled(golang(github.com/cihub/seelog))
 %global	conf_dir %{_sysconfdir}/ecs
 %global cache_dir %{_localstatedir}/cache/ecs
 %global data_dir %{_sharedstatedir}/ecs/data
+%global dhclient_dir %{_sharedstatedir}/ecs/dhclient
 %global man_dir %{_mandir}/man1
 %global rpmstate_dir /var/run
 %global running_semaphore %{rpmstate_dir}/ecs-init.was-running
@@ -75,6 +76,7 @@ mkdir -p $RPM_BUILD_ROOT/%{bin_dir}
 mkdir -p $RPM_BUILD_ROOT/%{conf_dir}
 mkdir -p $RPM_BUILD_ROOT/%{cache_dir}
 mkdir -p $RPM_BUILD_ROOT/%{data_dir}
+mkdir -p $RPM_BUILD_ROOT/%{dhclient_dir}
 mkdir -p $RPM_BUILD_ROOT/%{man_dir}
 
 install %{SOURCE1} $RPM_BUILD_ROOT/%{init_dir}/ecs.conf
@@ -95,6 +97,7 @@ touch $RPM_BUILD_ROOT/%{cache_dir}/state
 %ghost %{cache_dir}/ecs-agent.tar
 %{cache_dir}/state
 %dir %{data_dir}
+%ghost %{dhclient_dir}
 
 %clean
 rm scripts/amazon-ecs-init.1.gz

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -27,7 +27,7 @@ Source1:        ecs.conf
 
 BuildRequires:  golang >= 1.7
 
-Requires:       docker >= 1.6.0, docker <= 17.03.2ce
+Requires:       docker = 17.03.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps


### PR DESCRIPTION
### Summary
Changes required to start the Agent with Task ENI flag/feature enabled

### Details
* 555ca37 ecs-init/docker,packaging/amazon-linux-ami: start agent with --init
* 393b051 packaging/amazon-linux-ami: modify spec file with dhclient dependencies
* 7ccbab5 ecs-init/docker,ecs-init/config: modify agent create options to support task enis

### Testing Done
* [X] build (`make clean rpm`) succeeds
* [X] tests (`make gotest`) succeed
* [X] manual tests (installed the RPM and started the ECS Agent and verified that it registers with the `task-eni` capability)