### PR TITLE
Disable task enis on suse/ubuntu

### DIFF
--- a/ecs-init/docker/dependencies.go
+++ b/ecs-init/docker/dependencies.go
@@ -28,15 +28,6 @@ import (
 	godocker "github.com/fsouza/go-dockerclient"
 )
 
-const (
-	// dockerClientAPIVersion specifies the minimum docker client API version
-	// required by ECS Init
-	// Version 1.25 is required for setting Init to true when constructing
-	// the HostConfig for creating the ECS Agent to enable the Task
-	// Networking with ENI capability
-	dockerClientAPIVersion = "1.25"
-)
-
 type dockerclient interface {
 	ListImages(opts godocker.ListImagesOptions) ([]godocker.APIImages, error)
 	LoadImage(opts godocker.LoadImageOptions) error

--- a/ecs-init/docker/dependencies_suse_ubuntu.go
+++ b/ecs-init/docker/dependencies_suse_ubuntu.go
@@ -1,0 +1,22 @@
+// +build suse ubuntu
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+const (
+	// dockerClientAPIVersion specifies the minimum docker client API version
+	// required by ECS Init
+	dockerClientAPIVersion = "1.15"
+)

--- a/ecs-init/docker/dependencies_unspecified.go
+++ b/ecs-init/docker/dependencies_unspecified.go
@@ -1,0 +1,25 @@
+// +build !suse,!ubuntu
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+const (
+	// dockerClientAPIVersion specifies the minimum docker client API version
+	// required by ECS Init
+	// Version 1.25 is required for setting Init to true when constructing
+	// the HostConfig for creating the ECS Agent to enable the Task
+	// Networking with ENI capability
+	dockerClientAPIVersion = "1.25"
+)

--- a/ecs-init/docker/docker_suse_ubuntu.go
+++ b/ecs-init/docker/docker_suse_ubuntu.go
@@ -1,0 +1,33 @@
+// +build suse ubuntu
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+import godocker "github.com/fsouza/go-dockerclient"
+
+// getPlatformSpecificEnvVariables gets a map of environment variable key-value
+// pairs to set in the Agent's container config
+func getPlatformSpecificEnvVariables() map[string]string {
+	return map[string]string{}
+}
+
+// createHostConfig creates the host config for the ECS Agent container
+func createHostConfig(binds []string) *godocker.HostConfig {
+	return &godocker.HostConfig{
+		Binds:       binds,
+		NetworkMode: networkMode,
+		UsernsMode:  usernsMode,
+	}
+}

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -1,0 +1,50 @@
+// +build !suse,!ubuntu
+
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package docker
+
+import (
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
+	godocker "github.com/fsouza/go-dockerclient"
+)
+
+// getPlatformSpecificEnvVariables gets a map of environment variable key-value
+// pairs to set in the Agent's container config
+// The ECS_ENABLE_TASK_ENI flag is only set for Amazon Linux AMI
+func getPlatformSpecificEnvVariables() map[string]string {
+	return map[string]string{
+		"ECS_ENABLE_TASK_ENI": "true",
+	}
+}
+
+// createHostConfig creates the host config for the ECS Agent container
+// It mounts dhclient executable, leases and pid file directories when built
+// for Amazon Linux AMI
+func createHostConfig(binds []string) *godocker.HostConfig {
+	binds = append(binds, []string{
+		config.ProcFS + ":" + hostProcDir + readOnly,
+		config.AgentDHClientLeasesDirectory() + ":" + dhclientLeasesLocation,
+		dhclientLibDir + ":" + dhclientLibDir + readOnly,
+		dhclientExecutableDir + ":" + dhclientExecutableDir + readOnly,
+	}...)
+
+	return &godocker.HostConfig{
+		Binds:       binds,
+		NetworkMode: networkMode,
+		UsernsMode:  usernsMode,
+		CapAdd:      []string{CapNetAdmin, CapSysAdmin},
+		Init:        true,
+	}
+}


### PR DESCRIPTION
### Summary
disable task eni feature on suse and ubuntu

### Details
Respect build flags when building Agent container config and host config to disable the Task ENI feature on suse and ubuntu platforms

### Testing Done
* [X] `make clean rpm` 
* [X] `make test-in-docker`
* [X]  `./scripts/gobuild.sh suse`
* [X]  `./scripts/gobuild.sh ubuntu`
* [X]  Manual testing: Verified that `ECS_ENABLE_TASK_ENI=true` is set only when Init is built for Amazon Linux and disabled when built with `suse` and `ubuntu` tags by inspecting the Agent container