### PR TITLE
Backout task eni changes

### DIFF
--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -227,7 +227,6 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"]`, envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
-	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)
 
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)
@@ -235,8 +234,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 
 	hostCfg := opts.HostConfig
 
-	if len(hostCfg.Binds) != 9 {
-		t.Errorf("Expected exactly 9 elements to be in Binds, but was %d", len(hostCfg.Binds))
+	if len(hostCfg.Binds) != 5 {
+		t.Errorf("Expected exactly 5 elements to be in Binds, but was %d", len(hostCfg.Binds))
 	}
 	binds := make(map[string]struct{})
 	for _, binding := range hostCfg.Binds {
@@ -248,38 +247,9 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentDataDirectory()+":/data", binds, t)
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
-	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
-	expectKey(config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation, binds, t)
-	expectKey(dhclientLibDir+":"+dhclientLibDir+":ro", binds, t)
-	expectKey(dhclientExecutableDir+":"+dhclientExecutableDir+":ro", binds, t)
 
 	if hostCfg.NetworkMode != networkMode {
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)
-	}
-
-	if len(hostCfg.CapAdd) != 2 {
-		t.Error("Mismatch detected in added host config capabilities")
-	}
-
-	capNetAdminFound := false
-	capSysAdminFound := false
-	for _, cap := range hostCfg.CapAdd {
-		if cap == CapNetAdmin {
-			capNetAdminFound = true
-		}
-		if cap == CapSysAdmin {
-			capSysAdminFound = true
-		}
-	}
-	if !capNetAdminFound {
-		t.Errorf("Missing %s from host config capabilities", CapNetAdmin)
-	}
-	if !capSysAdminFound {
-		t.Errorf("Missing %s from host config capabilities", CapSysAdmin)
-	}
-
-	if hostCfg.Init != true {
-		t.Error("Incorrect host config. Expected Init to be true")
 	}
 }
 

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -16,35 +16,20 @@
 package docker
 
 import (
-	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	godocker "github.com/fsouza/go-dockerclient"
 )
 
 // getPlatformSpecificEnvVariables gets a map of environment variable key-value
 // pairs to set in the Agent's container config
-// The ECS_ENABLE_TASK_ENI flag is only set for Amazon Linux AMI
 func getPlatformSpecificEnvVariables() map[string]string {
-	return map[string]string{
-		"ECS_ENABLE_TASK_ENI": "true",
-	}
+	return map[string]string{}
 }
 
 // createHostConfig creates the host config for the ECS Agent container
-// It mounts dhclient executable, leases and pid file directories when built
-// for Amazon Linux AMI
 func createHostConfig(binds []string) *godocker.HostConfig {
-	binds = append(binds, []string{
-		config.ProcFS + ":" + hostProcDir + readOnly,
-		config.AgentDHClientLeasesDirectory() + ":" + dhclientLeasesLocation,
-		dhclientLibDir + ":" + dhclientLibDir + readOnly,
-		dhclientExecutableDir + ":" + dhclientExecutableDir + readOnly,
-	}...)
-
 	return &godocker.HostConfig{
 		Binds:       binds,
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
-		CapAdd:      []string{CapNetAdmin, CapSysAdmin},
-		Init:        true,
 	}
 }

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -27,7 +27,7 @@ Source1:        ecs.conf
 
 BuildRequires:  golang >= 1.7
 
-Requires:       docker = 17.03.2ce
+Requires:       docker >= 17.03.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -31,7 +31,7 @@ Requires:       docker = 17.03.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps
-Requires:       dhclient
+Requires(post): docker >= 1.6.0
 
 Provides:       bundled(docker)
 Provides:       bundled(golang(github.com/docker/docker/pkg/archive))
@@ -53,7 +53,6 @@ Provides:       bundled(golang(github.com/cihub/seelog))
 %global	conf_dir %{_sysconfdir}/ecs
 %global cache_dir %{_localstatedir}/cache/ecs
 %global data_dir %{_sharedstatedir}/ecs/data
-%global dhclient_dir %{_sharedstatedir}/ecs/dhclient
 %global man_dir %{_mandir}/man1
 %global rpmstate_dir /var/run
 %global running_semaphore %{rpmstate_dir}/ecs-init.was-running
@@ -76,7 +75,6 @@ mkdir -p $RPM_BUILD_ROOT/%{bin_dir}
 mkdir -p $RPM_BUILD_ROOT/%{conf_dir}
 mkdir -p $RPM_BUILD_ROOT/%{cache_dir}
 mkdir -p $RPM_BUILD_ROOT/%{data_dir}
-mkdir -p $RPM_BUILD_ROOT/%{dhclient_dir}
 mkdir -p $RPM_BUILD_ROOT/%{man_dir}
 
 install %{SOURCE1} $RPM_BUILD_ROOT/%{init_dir}/ecs.conf
@@ -97,7 +95,6 @@ touch $RPM_BUILD_ROOT/%{cache_dir}/state
 %ghost %{cache_dir}/ecs-agent.tar
 %{cache_dir}/state
 %dir %{data_dir}
-%ghost %{dhclient_dir}
 
 %clean
 rm scripts/amazon-ecs-init.1.gz

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -149,10 +149,6 @@ if [ -e %{running_semaphore} ]; then
 fi
 
 %changelog
-* UNRELEASED
-- Add functionality for running the Agent with --init flag 
-- Mount /proc directory for Agent to access network namespace of containers for Task ENI feature
-- Add functionality for running the Agent with NET_ADMIN and SYS_ADMIN capabilities
 * Wed Aug 22 2017 Justin Haynes <jushay@amazon.com> - 1.14.4-1
 - Cache Agent version 1.14.4
 - Add support for Docker 17.03.2ce


### PR DESCRIPTION
### Summary

Backs out most of the Task ENI changes in ECS Init for the ECS Agent. The only effective change is requiring docker version >= `17.03.2ce` and API client version `1.25` for amazon linux.

### Testing
- [X] Build succeeds
```
$ make clean test-in-docker rpm; echo $?
0
```
- [X] Binds are as expected
```
$ docker inspect ecs-agent --format '{{.HostConfig.Binds}}'
[/var/run:/var/run /var/log/ecs:/log /var/lib/ecs/data:/data /etc/ecs:/etc/ecs /var/cache/ecs:/var/cache/ecs]
```

- [X] Env config is as expected
```
$ docker inspect ecs-agent --format '{{.Config.Env}}'
[AWS_DEFAULT_REGION=us-west-2 ECS_DATADIR=/data ECS_UPDATES_ENABLED=true ECS_ENABLE_TASK_IAM_ROLE=true ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true ECS_UPDATE_DOWNLOAD_DIR=/var/cache/ecs ECS_LOGLEVEL=debug ECS_CLUSTER=aithal-eni ECS_LOGFILE=/log/ecs-agent.log ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"] ECS_AGENT_CONFIG_FILE_PATH=/etc/ecs/ecs.config.json ECS_BACKEND_HOST=https://madison.us-west-2.amazonaws.com PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
```

- [X] Capabilities are as expected
```
$ docker inspect ecs-agent --format '{{.HostConfig.CapAdd}}'
[]
```