### PR TITLE
reenable Task ENI changes for the Agent

### DIFF
--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -31,7 +31,7 @@ Requires:       docker >= 17.03.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps
-Requires(post): docker >= 1.6.0
+Requires:       dhclient
 
 Provides:       bundled(docker)
 Provides:       bundled(golang(github.com/docker/docker/pkg/archive))
@@ -53,6 +53,7 @@ Provides:       bundled(golang(github.com/cihub/seelog))
 %global	conf_dir %{_sysconfdir}/ecs
 %global cache_dir %{_localstatedir}/cache/ecs
 %global data_dir %{_sharedstatedir}/ecs/data
+%global dhclient_dir %{_sharedstatedir}/ecs/dhclient
 %global man_dir %{_mandir}/man1
 %global rpmstate_dir /var/run
 %global running_semaphore %{rpmstate_dir}/ecs-init.was-running
@@ -75,6 +76,7 @@ mkdir -p $RPM_BUILD_ROOT/%{bin_dir}
 mkdir -p $RPM_BUILD_ROOT/%{conf_dir}
 mkdir -p $RPM_BUILD_ROOT/%{cache_dir}
 mkdir -p $RPM_BUILD_ROOT/%{data_dir}
+mkdir -p $RPM_BUILD_ROOT/%{dhclient_dir}
 mkdir -p $RPM_BUILD_ROOT/%{man_dir}
 
 install %{SOURCE1} $RPM_BUILD_ROOT/%{init_dir}/ecs.conf
@@ -95,6 +97,7 @@ touch $RPM_BUILD_ROOT/%{cache_dir}/state
 %ghost %{cache_dir}/ecs-agent.tar
 %{cache_dir}/state
 %dir %{data_dir}
+%ghost %{dhclient_dir}
 
 %clean
 rm scripts/amazon-ecs-init.1.gz


### PR DESCRIPTION
This PR undoes the commit from #117 and re-enables the Task ENI changes

### Testing Done
- [X] Build succeeds
```
$ make clean test-in-docker rpm; echo $?
0
```
- [X] Binds are as expected
```
$ docker inspect ecs-agent --format '{{.HostConfig.Binds}}'
[/var/run:/var/run /var/log/ecs:/log /var/lib/ecs/data:/data /etc/ecs:/etc/ecs /var/cache/ecs:/var/cache/ecs /proc:/host/proc:ro /var/lib/ecs/dhclient:/var/lib/dhclient /lib64:/lib64:ro /sbin:/sbin:ro]
```

- [X] Env config is as expected
```
$ docker inspect ecs-agent --format '{{.Config.Env}}'
[ECS_CLUSTER=aithal-eni ECS_LOGFILE=/log/ecs-agent.log ECS_ENABLE_TASK_ENI=true ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"] ECS_ENABLE_TASK_IAM_ROLE=true ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true ECS_AGENT_CONFIG_FILE_PATH=/etc/ecs/ecs.config.json ECS_UPDATE_DOWNLOAD_DIR=/var/cache/ecs ECS_LOGLEVEL=debug ECS_DATADIR=/data ECS_UPDATES_ENABLED=true AWS_DEFAULT_REGION=us-west-2 ECS_BACKEND_HOST=https://madison.us-west-2.amazonaws.com PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
```

- [X] Capabilities are as expected
```
$ docker inspect ecs-agent --format '{{.HostConfig.CapAdd}}'
[NET_ADMIN SYS_ADMIN]
```