### PR TITLE
add 'none' logging driver to ECS Agent's config

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -196,7 +196,7 @@ func (c *Client) getContainerConfig() *godocker.Config {
 		"ECS_AGENT_CONFIG_FILE_PATH":            config.AgentJSONConfigFile(),
 		"ECS_UPDATE_DOWNLOAD_DIR":               config.CacheDirectory(),
 		"ECS_UPDATES_ENABLED":                   "true",
-		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs"]`,
+		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs","none"]`,
 		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 	}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -224,7 +224,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_AGENT_CONFIG_FILE_PATH="+config.AgentJSONConfigFile(), envVariables, t)
 	expectKey("ECS_UPDATE_DOWNLOAD_DIR="+config.CacheDirectory(), envVariables, t)
 	expectKey("ECS_UPDATES_ENABLED=true", envVariables, t)
-	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs"]`, envVariables, t)
+	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs","none"]`,
+		envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)


### PR DESCRIPTION
### Description
This commit modifies the `ECS_AVAILABLE_LOGGING_DRIVERS` env var
for the Agent to include `none` logging driver. This compliments
https://github.com/aws/amazon-ecs-agent/pull/1041 PR in the
ECS Agent repository.

### Testing Done
- [X] build and test
```
$ make clean test-in-docker rpm; echo $?
0
```
- [X] Manual testing
```
$ sudo start ecs
$ docker inspect ecs-agent -f '{{.Config.Env}}' | less
[... ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs","none"] ...]
$ aws ecs describe-container-instances --cluster $ECS_CLUSTER --container-instance $INSTANCE --query containerInstances[0].attributes[2]
{
    "name": "com.amazonaws.ecs.capability.logging-driver.none"
}
```
### Changelog entry
```
- Add 'none' logging driver to ECS agent's config
```