### PR TITLE
add support for awslogs execution role

### DIFF
--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -229,6 +229,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)
+	expectKey("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true", envVariables, t)
 
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -25,7 +25,8 @@ import (
 // The ECS_ENABLE_TASK_ENI flag is only set for Amazon Linux AMI
 func getPlatformSpecificEnvVariables() map[string]string {
 	return map[string]string{
-		"ECS_ENABLE_TASK_ENI": "true",
+		"ECS_ENABLE_TASK_ENI":                       "true",
+		"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE": "true",
 	}
 }
 

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -27,7 +27,7 @@ Source1:        ecs.conf
 
 BuildRequires:  golang >= 1.7
 
-Requires:       docker >= 17.03.2ce
+Requires:       docker >= 17.06.2ce
 Requires:       upstart
 Requires:       iptables
 Requires:       procps


### PR DESCRIPTION
This change introduces a new `ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE` environment variable to enable the corresponding agent feature. Also increment the required docker version to `17.06.2ce`. The docker version bump is required since it includes the awslogs credentials endpoint flag introduced here https://github.com/moby/moby/pull/35055