### PR TITLE
Handle wrapped error for docker connect retry

### DIFF
--- a/ecs-init/docker/dependencies.go
+++ b/ecs-init/docker/dependencies.go
@@ -75,7 +75,7 @@ func newDockerClient(dockerClientFactory dockerClientFactory, pingBackoff backof
 			break
 		}
 		backoffDuration := pingBackoff.Duration()
-		log.Infof("Network error connecting to docker, backing off for '%v', error: %v", backoffDuration, err)
+		log.Infof("Error connecting to docker, backing off for %s, error: %s", backoffDuration, err)
 		time.Sleep(backoffDuration)
 	}
 	return &_dockerclient{

--- a/ecs-init/docker/dependencies_test.go
+++ b/ecs-init/docker/dependencies_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+const immediately = time.Duration(-1)
+
 var netError = &url.Error{Err: &net.OpError{Op: "read", Net: "unix", Err: io.EOF}}
 var httpError = &docker.Error{Status: http.StatusInternalServerError, Message: "error"}
 
@@ -65,7 +67,7 @@ func TestNewDockerClientRetriesOnPingNetworkError(t *testing.T) {
 		mockClientFactory.EXPECT().NewVersionedClient(gomock.Any(), gomock.Any()).Return(mockDockerClient, nil),
 		mockDockerClient.EXPECT().Ping().Return(netError),
 		mockBackoff.EXPECT().ShouldRetry().Return(true),
-		mockBackoff.EXPECT().Duration().Return(time.Microsecond),
+		mockBackoff.EXPECT().Duration().Return(immediately),
 		mockDockerClient.EXPECT().Ping().Return(nil),
 	)
 
@@ -87,7 +89,7 @@ func TestNewDockerClientRetriesOnHTTPStatusNotOKError(t *testing.T) {
 		mockClientFactory.EXPECT().NewVersionedClient(gomock.Any(), gomock.Any()).Return(mockDockerClient, nil),
 		mockDockerClient.EXPECT().Ping().Return(httpError),
 		mockBackoff.EXPECT().ShouldRetry().Return(true),
-		mockBackoff.EXPECT().Duration().Return(time.Microsecond),
+		mockBackoff.EXPECT().Duration().Return(immediately),
 		mockDockerClient.EXPECT().Ping().Return(nil),
 	)
 
@@ -128,7 +130,7 @@ func TestNewDockerClientGivesUpRetryingOnPingNetworkError(t *testing.T) {
 		mockClientFactory.EXPECT().NewVersionedClient(gomock.Any(), gomock.Any()).Return(mockDockerClient, nil),
 		mockDockerClient.EXPECT().Ping().Return(netError),
 		mockBackoff.EXPECT().ShouldRetry().Return(true),
-		mockBackoff.EXPECT().Duration().Return(time.Microsecond),
+		mockBackoff.EXPECT().Duration().Return(immediately),
 		mockDockerClient.EXPECT().Ping().Return(netError),
 		mockBackoff.EXPECT().ShouldRetry().Return(false),
 	)
@@ -136,5 +138,41 @@ func TestNewDockerClientGivesUpRetryingOnPingNetworkError(t *testing.T) {
 	_, err := newDockerClient(mockClientFactory, mockBackoff)
 	if err == nil {
 		t.Error("Expected error creating docker client")
+	}
+}
+
+func TestNewDockerClientGivesUpRetryingOnUnavailableSocket(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClientFactory := NewMockdockerClientFactory(ctrl)
+	mockBackoff := NewMockBackoff(ctrl)
+
+	realDockerClient, dockerClientErr := godockerClientFactory{}.NewVersionedClient("unix:///a/bad/docker.sock", dockerClientAPIVersion)
+	if dockerClientErr != nil {
+		t.Fatal("error setting up intentionally bad client (nonexistent socket path)")
+	}
+
+	gomock.InOrder(
+		// We use the real client to ensure we're classifying errors
+		// correctly as returned by the upstream's error handling.
+		mockClientFactory.EXPECT().NewVersionedClient(gomock.Any(), gomock.Any()).Return(realDockerClient, dockerClientErr),
+		// "bad connection", retries
+		mockBackoff.EXPECT().ShouldRetry().Return(true),
+		mockBackoff.EXPECT().Duration().Return(immediately),
+		// Give up
+		mockBackoff.EXPECT().ShouldRetry().Return(false),
+	)
+
+	_, err := newDockerClient(mockClientFactory, mockBackoff)
+	if err == nil {
+		t.Fatal("Expected error creating docker client")
+	}
+
+	// We expect that the error will be a net.OpError wrapped by a
+	// url.Error.
+	_, isExpectedError := err.(*url.Error)
+	if !isExpectedError {
+		t.Fatal("Unexpected error type from docker client given a nonexistent path")
 	}
 }

--- a/ecs-init/docker/dependencies_test.go
+++ b/ecs-init/docker/dependencies_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-var netError = &net.OpError{Op: "read", Net: "unix", Err: io.EOF}
+var netError = &url.Error{Err: &net.OpError{Op: "read", Net: "unix", Err: io.EOF}}
 var httpError = &docker.Error{Status: http.StatusInternalServerError, Message: "error"}
 
 func TestIsNetworkErrorReturnsTrue(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Handles scenarios where the docker socket isn't yet available.

### Implementation details
I updated the condition in which the ping is retried.

### Testing
Tests were modified to reflect the wrapped error and I tested this with a bad path to be sure.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Fixed docker connection retry handling

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
