### PR TITLE
mount Docker plugin files dir

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -83,7 +83,22 @@ const (
 	CapSysAdmin = "SYS_ADMIN"
 	// DefaultCgroupMountpoint is the default mount point for the cgroup subsystem
 	DefaultCgroupMountpoint = "/sys/fs/cgroup"
+	// pluginSocketFilesDir specifies the location of UNIX domain socket files of
+	// Docker plugins
+	pluginSocketFilesDir = "/run/docker/plugins"
+	// pluginSpecFilesEtcDir specifies one of the locations of spec or json files
+	// of Docker plugins
+	pluginSpecFilesEtcDir = "/etc/docker/plugins"
+	// pluginSpecFilesUsrDir specifies one of the locations of spec or json files
+	// of Docker plugins
+	pluginSpecFilesUsrDir = "/usr/lib/docker/plugins"
 )
+
+var pluginDirs = []string{
+	pluginSocketFilesDir,
+	pluginSpecFilesEtcDir,
+	pluginSpecFilesUsrDir,
+}
 
 // Client enables business logic for running the Agent inside Docker
 type Client struct {
@@ -261,7 +276,16 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		config.CacheDirectory() + ":" + config.CacheDirectory(),
 		config.CgroupMountpoint() + ":" + DefaultCgroupMountpoint,
 	}
+	binds = append(binds, getDockerPluginDirBinds()...)
 	return createHostConfig(binds)
+}
+
+func getDockerPluginDirBinds() []string {
+	var pluginBinds []string
+	for _, pluginDir := range pluginDirs {
+		pluginBinds = append(pluginBinds, pluginDir+":"+pluginDir+readOnly)
+	}
+	return pluginBinds
 }
 
 // StopAgent stops the Agent in docker if one is running

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+const (
+	// expectedAgentBinds is the total number of agent host config binds.
+	// Note: Change this value every time when a new bind mount is added to agent for
+	// the tests to pass
+	expectedAgentBinds = 13
+)
+
 func TestIsAgentImageLoadedListFailure(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -237,8 +244,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 
 	hostCfg := opts.HostConfig
 
-	if len(hostCfg.Binds) != 10 {
-		t.Errorf("Expected exactly 10 elements to be in Binds, but was %d", len(hostCfg.Binds))
+	if len(hostCfg.Binds) != expectedAgentBinds {
+		t.Errorf("Expected exactly %d elements to be in Binds, but was %d", expectedAgentBinds, len(hostCfg.Binds))
 	}
 	binds := make(map[string]struct{})
 	for _, binding := range hostCfg.Binds {
@@ -254,6 +261,9 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation, binds, t)
 	expectKey(dhclientLibDir+":"+dhclientLibDir+":ro", binds, t)
 	expectKey(dhclientExecutableDir+":"+dhclientExecutableDir+":ro", binds, t)
+	for _, pluginDir := range pluginDirs {
+		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)
+	}
 
 	if hostCfg.NetworkMode != networkMode {
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)


### PR DESCRIPTION
### Summary
Mount Docker plugin files' directories in agent

### Implementation details
Docker plugins socket, spec and json files are present in three different directories on the host. More details [here](https://docs.docker.com/engine/extend/plugin_api/#plugin-discovery). Mount these directories to agent to use it for volume plugins discovery. 

### Testing

New tests cover the changes: yes

### Description for the changelog

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
