### PR TITLE
Add support for regional buckets

### DIFF
--- a/ecs-init/cache/dependencies_mock_test.go
+++ b/ecs-init/cache/dependencies_mock_test.go
@@ -27,31 +27,31 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mocks3Downloader is a mock of s3Downloader interface
-type Mocks3Downloader struct {
+// Mocks3API is a mock of s3API interface
+type Mocks3API struct {
 	ctrl     *gomock.Controller
-	recorder *Mocks3DownloaderMockRecorder
+	recorder *Mocks3APIMockRecorder
 }
 
-// Mocks3DownloaderMockRecorder is the mock recorder for Mocks3Downloader
-type Mocks3DownloaderMockRecorder struct {
-	mock *Mocks3Downloader
+// Mocks3APIMockRecorder is the mock recorder for Mocks3API
+type Mocks3APIMockRecorder struct {
+	mock *Mocks3API
 }
 
-// NewMocks3Downloader creates a new mock instance
-func NewMocks3Downloader(ctrl *gomock.Controller) *Mocks3Downloader {
-	mock := &Mocks3Downloader{ctrl: ctrl}
-	mock.recorder = &Mocks3DownloaderMockRecorder{mock}
+// NewMocks3API creates a new mock instance
+func NewMocks3API(ctrl *gomock.Controller) *Mocks3API {
+	mock := &Mocks3API{ctrl: ctrl}
+	mock.recorder = &Mocks3APIMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *Mocks3Downloader) EXPECT() *Mocks3DownloaderMockRecorder {
+func (m *Mocks3API) EXPECT() *Mocks3APIMockRecorder {
 	return m.recorder
 }
 
 // Download mocks base method
-func (m *Mocks3Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
+func (m *Mocks3API) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
 	varargs := []interface{}{w, input}
 	for _, a := range options {
 		varargs = append(varargs, a)
@@ -63,9 +63,55 @@ func (m *Mocks3Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, opt
 }
 
 // Download indicates an expected call of Download
-func (mr *Mocks3DownloaderMockRecorder) Download(w, input interface{}, options ...interface{}) *gomock.Call {
+func (mr *Mocks3APIMockRecorder) Download(w, input interface{}, options ...interface{}) *gomock.Call {
 	varargs := append([]interface{}{w, input}, options...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*Mocks3Downloader)(nil).Download), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*Mocks3API)(nil).Download), varargs...)
+}
+
+// Mocks3DownloaderAPI is a mock of s3DownloaderAPI interface
+type Mocks3DownloaderAPI struct {
+	ctrl     *gomock.Controller
+	recorder *Mocks3DownloaderAPIMockRecorder
+}
+
+// Mocks3DownloaderAPIMockRecorder is the mock recorder for Mocks3DownloaderAPI
+type Mocks3DownloaderAPIMockRecorder struct {
+	mock *Mocks3DownloaderAPI
+}
+
+// NewMocks3DownloaderAPI creates a new mock instance
+func NewMocks3DownloaderAPI(ctrl *gomock.Controller) *Mocks3DownloaderAPI {
+	mock := &Mocks3DownloaderAPI{ctrl: ctrl}
+	mock.recorder = &Mocks3DownloaderAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *Mocks3DownloaderAPI) EXPECT() *Mocks3DownloaderAPIMockRecorder {
+	return m.recorder
+}
+
+// addBucketDownloader mocks base method
+func (m *Mocks3DownloaderAPI) addBucketDownloader(bucketDownloader *s3BucketDownloader) {
+	m.ctrl.Call(m, "addBucketDownloader", bucketDownloader)
+}
+
+// addBucketDownloader indicates an expected call of addBucketDownloader
+func (mr *Mocks3DownloaderAPIMockRecorder) addBucketDownloader(bucketDownloader interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addBucketDownloader", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).addBucketDownloader), bucketDownloader)
+}
+
+// downloadFile mocks base method
+func (m *Mocks3DownloaderAPI) downloadFile(fileName string) (string, error) {
+	ret := m.ctrl.Call(m, "downloadFile", fileName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// downloadFile indicates an expected call of downloadFile
+func (mr *Mocks3DownloaderAPIMockRecorder) downloadFile(fileName interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "downloadFile", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).downloadFile), fileName)
 }
 
 // MockfileSystem is a mock of fileSystem interface

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -39,8 +39,8 @@ const (
 	// AgentFilename is the filename, including version number, of the agent to be downloaded.
 	AgentFilename = "ecs-agent-v1.17.3.tar"
 
-	// AgentRemoteBucketName is the name of the s3 bucket that stores the agent
-	AgentRemoteBucketName = "amazon-ecs-agent"
+	// AgentPartitionBucketName is the name of the paritional s3 bucket that stores the agent
+	AgentPartitionBucketName = "amazon-ecs-agent"
 
 	// DefaultRegionName is the default region to fall back if the user's region is not a region containing
 	// the agent bucket
@@ -53,8 +53,8 @@ var partitionBucketMap = map[string]string{
 	endpoints.AwsUsGovPartitionID: endpoints.UsGovWest1RegionID,
 }
 
-// GetAgentBucketRegion returns the s3 bucket region where ECS Agent artifact is located
-func GetAgentBucketRegion(region string) (string, error) {
+// GetAgentPartitionBucketRegion returns the s3 bucket region where ECS Agent artifact is located
+func GetAgentPartitionBucketRegion(region string) (string, error) {
 	regionPartition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
 	if !ok {
 		return "", errors.Errorf("GetAgentBucketRegion: partition not found for region: %s", region)

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -48,7 +48,7 @@ func TestDockerUnixSocketWithDockerHost(t *testing.T) {
 	}
 }
 
-func TestGetAgentBucketRegion(t *testing.T) {
+func TestGetAgentPartitionBucketRegion(t *testing.T) {
 	testCases := []struct {
 		region      string
 		destination string
@@ -72,7 +72,7 @@ func TestGetAgentBucketRegion(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(fmt.Sprintf("%s -> %s", testcase.region, testcase.destination),
 			func(t *testing.T) {
-				region, err := GetAgentBucketRegion(testcase.region)
+				region, err := GetAgentPartitionBucketRegion(testcase.region)
 				if region != "" && region != testcase.destination && err != nil {
 					t.Errorf("GetAgentBucketRegion returned unexpected region: %s, err: %v", region, err)
 				}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request adds support for regional buckets.

### Implementation details
<!-- How are the changes implemented? -->
The s3 downloader has two bucket downloaders internally, one corresponds to the partition bucket, another corresponds to the regional bucket. the download will succeed if either downloading from either bucket succeeds.

### Testing
<!-- How was this tested? -->
make test
Manual test is performed on the produced rpm.

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
