### PR TITLE
Add ecs systemd unit for al2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /ecs-init.spec
 /sources.tgz
 ecs-agent-*.tar
+ecs.service
+*.log

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ sources.tgz:
 	./scripts/update-version.sh
 	cp packaging/amazon-linux-ami/ecs-init.spec ecs-init.spec
 	cp packaging/amazon-linux-ami/ecs.conf ecs.conf
+	cp packaging/amazon-linux-ami/ecs.service ecs.service
 	tar -czf ./sources.tgz ecs-init scripts
 
 sources: sources.tgz
@@ -84,13 +85,15 @@ get-deps:
 	go get golang.org/x/tools/cmd/goimports
 
 clean:
-	-rm ecs-init.spec
-	-rm ecs.conf
-	-rm ./sources.tgz
-	-rm ./amazon-ecs-init
-	-rm ./ecs-init-*.src.rpm
-	-rm ./ecs-init-* -r
-	-rm -r ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
-	-rm ./x86_64 -r
-	-rm ./amazon-ecs-init_${VERSION}*
-	-rm .srpm-done .rpm-done
+	-rm -f ecs-init.spec
+	-rm -f ecs.conf
+	-rm -f ecs.service
+	-rm -f ./sources.tgz
+	-rm -f ./amazon-ecs-init
+	-rm -f ./ecs-agent-*.tar
+	-rm -f ./ecs-init-*.src.rpm
+	-rm -rf ./ecs-init-*
+	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
+	-rm -rf ./x86_64
+	-rm -f ./amazon-ecs-init_${VERSION}*
+	-rm -f .srpm-done .rpm-done

--- a/ecs-init/ecs-init.go
+++ b/ecs-init/ecs-init.go
@@ -31,6 +31,7 @@ const (
 	PRESTART = "pre-start"
 	START    = "start"
 	PRESTOP  = "pre-stop"
+	STOP     = "stop"
 	POSTSTOP = "post-stop"
 	RECACHE  = "reload-cache"
 )
@@ -91,7 +92,13 @@ func actions(engine *engine.Engine) map[string]action {
 			function:    engine.StartSupervised,
 			description: "Start the ECS Agent and wait for it to stop",
 		},
+		// This is a deprecated command for stopping the agent
+		// when using upstart jobs
 		PRESTOP: action{
+			function:    engine.PreStop,
+			description: "Stop the ECS Agent",
+		},
+		STOP: action{
 			function:    engine.PreStop,
 			description: "Stop the ECS Agent",
 		},

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -12,25 +12,36 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
+%if 0%{?amzn} >= 2
+%bcond_without systemd # with
+%else
+%bcond_with systemd # without
+%global running_semaphore %{_localstatedir}/run/ecs-init.was-running
+%endif
+%global _cachedir %{_localstatedir}/cache
+%global bundled_agent_version %{version}
+
 Name:           ecs-init
 Version:        1.18.0
-Release:        1%{?dist}
-Group:          System Environment/Base
-Vendor:         Amazon.com
+Release:        2%{?dist}
 License:        Apache 2.0
 Summary:        Amazon Elastic Container Service initialization application
-BuildArch:      x86_64
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+ExclusiveArch:  x86_64
 
 Source0:        sources.tgz
 Source1:        ecs.conf
 Source2:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-v%{bundled_agent_version}.tar
+Source3:        ecs.service
 
 BuildRequires:  golang >= 1.7
-
-Requires:       docker >= 17.06.2ce
+%if %{with systemd}
+BuildRequires:  systemd
+Requires:       systemd
+%else
 Requires:       upstart
+%endif
 Requires:       iptables
+Requires:       docker >= 17.06.2ce
 Requires:       procps
 Requires:       dhclient
 
@@ -124,17 +135,6 @@ Provides:       bundled(golang(golang.org/x/net/context/ctxhttp))
 Provides:       bundled(golang(golang.org/x/sys/unix))
 Provides:       bundled(golang(golang.org/x/sys/windows))
 
-%global bundled_agent_version %{version}
-%global init_dir %{_sysconfdir}/init
-%global bin_dir %{_libexecdir}
-%global conf_dir %{_sysconfdir}/ecs
-%global cache_dir %{_localstatedir}/cache/ecs
-%global data_dir %{_sharedstatedir}/ecs/data
-%global dhclient_dir %{_sharedstatedir}/ecs/dhclient
-%global man_dir %{_mandir}/man1
-%global rpmstate_dir /var/run
-%global running_semaphore %{rpmstate_dir}/ecs-init.was-running
-
 %description
 ecs-init is a service which may be run to register an EC2 instance as an Amazon
 ECS Container Instance.
@@ -144,230 +144,292 @@ ECS Container Instance.
 
 %build
 ./scripts/gobuild.sh
-gzip -c scripts/amazon-ecs-init.1 > scripts/amazon-ecs-init.1.gz
 
 %install
-rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/%{init_dir}
-mkdir -p $RPM_BUILD_ROOT/%{bin_dir}
-mkdir -p $RPM_BUILD_ROOT/%{conf_dir}
-mkdir -p $RPM_BUILD_ROOT/%{cache_dir}
-mkdir -p $RPM_BUILD_ROOT/%{data_dir}
-mkdir -p $RPM_BUILD_ROOT/%{dhclient_dir}
-mkdir -p $RPM_BUILD_ROOT/%{man_dir}
+install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
+install -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
 
-install %{SOURCE1} $RPM_BUILD_ROOT/%{init_dir}/ecs.conf
-install %{SOURCE2} $RPM_BUILD_ROOT/%{cache_dir}/ecs-agent-v%{bundled_agent_version}.tar
-install amazon-ecs-init $RPM_BUILD_ROOT/%{bin_dir}/amazon-ecs-init
-install scripts/amazon-ecs-init.1.gz $RPM_BUILD_ROOT/%{man_dir}/amazon-ecs-init.1.gz
-touch $RPM_BUILD_ROOT/%{conf_dir}/ecs.config
-touch $RPM_BUILD_ROOT/%{conf_dir}/ecs.config.json
+mkdir -p %{buildroot}%{_sysconfdir}/ecs
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
+
+install -D %{SOURCE2} %{buildroot}%{_cachedir}/ecs/ecs-agent-v%{bundled_agent_version}.tar
 # Configure ecs-init to reload the bundled ECS Agent image.
-echo 2 > $RPM_BUILD_ROOT/%{cache_dir}/state
+mkdir -p %{buildroot}%{_cachedir}/ecs
+echo 2 > %{buildroot}%{_cachedir}/ecs/state
+
+mkdir -p %{buildroot}%{_sharedstatedir}/ecs/{data,dhclient}
+
+%if %{with systemd}
+install -D %{SOURCE3} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+%else
+install -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
+%endif
 
 %files
-%defattr(-,root,root,-)
-%{init_dir}/ecs.conf
-%{bin_dir}/amazon-ecs-init
-%{man_dir}/amazon-ecs-init.1.gz
-%config(noreplace) %ghost %{conf_dir}/ecs.config
-%config(noreplace) %ghost %{conf_dir}/ecs.config.json
-%ghost %{cache_dir}/ecs-agent.tar
-%{cache_dir}/ecs-agent-v%{bundled_agent_version}.tar
-%{cache_dir}/state
-%dir %{data_dir}
-%ghost %{dhclient_dir}
+%{_libexecdir}/amazon-ecs-init
+%{_mandir}/man1/amazon-ecs-init.1*
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
+%ghost %{_cachedir}/ecs/ecs-agent.tar
+%{_cachedir}/ecs/ecs-agent-v%{bundled_agent_version}.tar
+%{_cachedir}/ecs/state
+%dir %{_sharedstatedir}/ecs/data
+%ghost %{_sharedstatedir}/ecs/dhclient
 
-%clean
-rm scripts/amazon-ecs-init.1.gz
-rm -rf $RPM_BUILD_ROOT
+%if %{with systemd}
+%{_unitdir}/ecs.service
+%else
+%{_sysconfdir}/init/ecs.conf
+%endif
 
+%if %{with systemd}
+%post
+# Symlink the bundled ECS Agent at loadable path.
+ln -sf ecs-agent-v%{bundled_agent_version}.tar %{_cachedir}/ecs/ecs-agent.tar
+%systemd_post ecs
+
+%postun
+%systemd_postun
+%else
 %triggerun -- docker
 # record whether or not our service was running when docker is upgraded
 ecs_status=$(/sbin/status ecs 2>/dev/null || :)
 if grep -qF "start/" <<< "${ecs_status}"; then
-    /sbin/stop ecs >/dev/null 2>&1 || :
-    if [ "$1" -ge 1 ]; then
-        # write semaphore if this package is still installed
-        touch %{running_semaphore} >/dev/null 2>&1 || :
-    fi
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	if [ "$1" -ge 1 ]; then
+		# write semaphore if this package is still installed
+		touch %{running_semaphore} >/dev/null 2>&1 || :
+	fi
 fi
 
 %triggerpostun -- docker
 # ensures that ecs-init is restarted after docker or ecs-init is upgraded
 if [ "$1" -ge 1 ] && [ -e %{running_semaphore} ]; then
-    /sbin/start ecs >/dev/null 2>&1 || :
-    rm %{running_semaphore} >/dev/null 2>&1 ||:
+	/sbin/start ecs >/dev/null 2>&1 || :
+	rm %{running_semaphore} >/dev/null 2>&1 ||:
 fi
-
-%post
-# Symlink the bundled ECS Agent at loadable path.
-ln -sf ecs-agent-v%{bundled_agent_version}.tar %{cache_dir}/ecs-agent.tar
 
 %postun
 # record whether or not our service was running when ecs-init is upgraded
 ecs_status=$(/sbin/status ecs 2>/dev/null || :)
 if grep -qF "start/" <<< "${ecs_status}"; then
-    /sbin/stop ecs >/dev/null 2>&1 || :
-    if [ "$1" -ge 1 ]; then
-        # write semaphore if this package is upgraded
-        touch %{running_semaphore} >/dev/null 2>&1 || :
-    fi
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	if [ "$1" -ge 1 ]; then
+		# write semaphore if this package is upgraded
+		touch %{running_semaphore} >/dev/null 2>&1 || :
+	fi
 fi
 # remove semaphore if this package is erased
 if [ "$1" -eq 0 ]; then
-    rm %{running_semaphore} >/dev/null 2>&1 || :
+	rm %{running_semaphore} >/dev/null 2>&1 || :
 fi
 
 %triggerun -- ecs-init <= 1.0-3
 # handle old ecs-init package that does not properly stop
 ecs_status=$(/sbin/status ecs 2>/dev/null || :)
 if grep -qF "start/" <<< "${ecs_status}"; then
-    /sbin/stop ecs >/dev/null 2>&1 || :
-    touch %{running_semaphore} >/dev/null 2>&1 || :
+	/sbin/stop ecs >/dev/null 2>&1 || :
+	touch %{running_semaphore} >/dev/null 2>&1 || :
 fi
 
 %posttrans
 # ensure that we restart after the transaction
 if [ -e %{running_semaphore} ]; then
-    /sbin/start ecs >/dev/null 2>&1 || :
-    rm %{running_semaphore} >/dev/null 2>&1 || :
+	/sbin/start ecs >/dev/null 2>&1 || :
+	rm %{running_semaphore} >/dev/null 2>&1 || :
 fi
+%endif
 
 %changelog
+* Wed May 23 2018 iliana weller <iweller@amazon.com> - 1.18.0-2
+- Spec file cleanups
+- Enable builds for both AL1 and AL2
+
 * Fri May 04 2018 Haikuo Liu <haikuo@amazon.com> - 1.18.0-1
 - Cache Agent vesion 1.18.0
 - Add support for regional buckets
 - Bundle ECS Agent tarball in package
 - Download agent based on the partition
 - Mount Docker plugin files dir
+
 * Fri Mar 30 2018 Justin Haynes <jushay@amazon.com> - 1.17.3-1
 - Cache Agent vesion 1.17.3
 - Use s3client instead of httpclient when downloading
+
 * Mon Mar 05 2018 Jacob Vallejo <jakeev@amazon.com> - 1.17.2-1
 - Cache Agent vesion 1.17.2
+
 * Mon Feb 19 2018 Justin Haynes <jushay@amazon.com> - 1.17.1-1
 - Cache Agent vesion 1.17.1
+
 * Mon Feb 05 2018 Justin Haynes <jushay@amazon.com> - 1.17.0-2
 - Cache Agent vesion 1.17.0
+
 * Tue Jan 16 2018 Derek Petersen <petderek@amazon.com> - 1.16.2-1
 - Cache Agent version 1.16.2
 - Add GovCloud endpoint
+
 * Wed Jan 03 2018 Noah Meyerhans <nmeyerha@amazon.com> - 1.16.1-1
 - Cache Agent version 1.16.1
 - Improve startup behavior when docker socket does not yet exist
+
 * Tue Nov 21 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.16.0-1
 - Cache Agent vesion 1.16.0
+
 * Thu Nov 16 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.15.2-2
 - Correct the agent 1.15.2 filename
+
 * Tue Nov 14 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.15.2-1
 - Cache Agent version 1.15.2
+
 * Mon Nov  6 2017 Jacob Vallejo <jakeev@amazon.com> - 1.15.1-1
 - Cache Agent version 1.15.1
+
 * Mon Oct 30 2017 Justin Haynes <jushay@amazon.com> - 1.15.0-4
 - Cache Agent version 1.15.0
 - Add 'none' logging driver to ECS agent's config
+
 * Fri Sep 29 2017 Justin Haynes <jushay@amazon.com> - 1.14.5-1
 - Cache Agent version 1.14.5
+
 * Tue Aug 22 2017 Justin Haynes <jushay@amazon.com> - 1.14.4-1
 - Cache Agent version 1.14.4
 - Add support for Docker 17.03.2ce
+
 * Fri Jun 9 2017 Adnan Khan <adnkha@amazon.com> - 1.14.3-1
 - Cache Agent version 1.14.3
+
 * Thu Jun 1 2017 Adnan Khan <adnkha@amazon.com> - 1.14.2-2
 - Cache Agent version 1.14.2
 - Add functionality for running agent with userns=host when Docker has userns-remap enabled
 - Add support for Docker 17.03.1ce
+
 * Mon Mar 6 2017 Adnan Khan <adnkha@amazon.com> - 1.14.1-1
 - Cache Agent version 1.14.1
+
 * Wed Jan 25 2017 Anirudh Aithal <aithal@amazon.com> - 1.14.0-2
 - Add retry-backoff for pinging the Docker socket when creating the Docker client
+
 * Mon Jan 16 2017 Derek Petersen <petderek@amazon.com> - 1.14.0-1
 - Cache Agent version 1.14.0
+
 * Fri Jan  6 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.13.1-2
 - Update Requires to indicate support for docker <= 1.12.6
+
 * Mon Nov 14 2016 Peng Yin <penyin@amazon.com> - 1.13.1-1
 - Cache Agent version 1.13.1
+
 * Tue Sep 27 2016 Noah Meyerhans <nmeyerha@amazon.com> - 1.13.0-1
 - Cache Agent version 1.13.0
+
 * Tue Sep 13 2016 Anirudh Aithal <aithal@amazon.com> - 1.12.2-1
 - Cache Agent version 1.12.2
+
 * Wed Aug 17 2016 Peng Yin <penyin@amazon.com> - 1.12.1-1
 - Cache Agent version 1.12.1
+
 * Wed Aug 10 2016 Anirudh Aithal <aithal@amazon.com> - 1.12.0-1
 - Cache Agent version 1.12.0
 - Add netfilter rules to support host network reaching credentials proxy
+
 * Wed Aug 3 2016 Samuel Karp <skarp@amazon.com> - 1.11.1-1
 - Cache Agent version 1.11.1
+
 * Tue Jul 5 2016 Samuel Karp <skarp@amazon.com> - 1.11.0-1
 - Cache Agent version 1.11.0
 - Add support for Docker 1.11.2
 - Modify iptables and netfilter to support credentials proxy
 - Eliminate requirement that /tmp and /var/cache be on the same filesystem
 - Start agent with host network mode
+
 * Mon May 23 2016 Peng Yin <penyin@amazon.com> - 1.10.0-1
 - Cache Agent version 1.10.0
 - Add support for Docker 1.11.1
+
 * Tue Apr 26 2016 Peng Yin <penyin@amazon.com> - 1.9.0-1
 - Cache Agent version 1.9.0
 - Make awslogs driver available by default
+
 * Thu Mar 24 2016 Juan Rhenals <rhenalsj@amazon.com> - 1.8.2-1
 - Cache Agent version 1.8.2
+
 * Mon Feb 29 2016 Juan Rhenals <rhenalsj@amazon.com> - 1.8.1-1
 - Cache Agent version 1.8.1
+
 * Wed Feb 10 2016 Juan Rhenals <rhenalsj@amazon.com> - 1.8.0-1
 - Cache Agent version 1.8.0
+
 * Fri Jan 8 2016 Samuel Karp <skarp@amazon.com> - 1.7.1-1
 - Cache Agent version 1.7.1
+
 * Tue Dec 8 2015 Samuel Karp <skarp@amazon.com> - 1.7.0-1
 - Cache Agent version 1.7.0
 - Add support for Docker 1.9.1
+
 * Wed Oct 21 2015 Samuel Karp <skarp@amazon.com> - 1.6.0-1
 - Cache Agent version 1.6.0
 - Updated source dependencies
+
 * Wed Sep 23 2015 Samuel Karp <skarp@amazon.com> - 1.5.0-1
 - Cache Agent version 1.5.0
 - Improved merge strategy for user-supplied environment variables
 - Add default supported logging drivers
+
 * Wed Aug 26 2015 Samuel Karp <skarp@amazon.com> - 1.4.0-2
 - Add support for Docker 1.7.1
+
 * Tue Aug 11 2015 Samuel Karp <skarp@amazon.com> - 1.4.0-1
 - Cache Agent version 1.4.0
+
 * Thu Jul 30 2015 Samuel Karp <skarp@amazon.com> - 1.3.1-1
 - Cache Agent version 1.3.1
 - Read Docker endpoint from environment variable DOCKER_HOST if present
+
 * Thu Jul 2 2015 Samuel Karp <skarp@amazon.com> - 1.3.0-1
 - Cache Agent version 1.3.0
+
 * Fri Jun 19 2015 Euan Kemp <euank@amazon.com> - 1.2.1-2
 - Cache Agent version 1.2.1
+
 * Tue Jun 2 2015 Samuel Karp <skarp@amazon.com> - 1.2.0-1
 - Update versioning scheme to match Agent version
 - Cache Agent version 1.2.0
 - Mount cgroup and execdriver directories for Telemetry feature
+
 * Mon Jun 1 2015 Samuel Karp <skarp@amazon.com> - 1.0-5
 - Add support for Docker 1.6.2
+
 * Mon May 11 2015 Samuel Karp <skarp@amazon.com> - 1.0-4
 - Properly restart if the ecs-init package is upgraded in isolation
+
 * Wed May 6 2015 Samuel Karp <skarp@amazon.com> - 1.0-3
 - Restart on upgrade if already running
+
 * Tue May 5 2015 Samuel Karp <skarp@amazon.com> - 1.0-2
 - Cache Agent version 1.1.0
 - Add support for Docker 1.6.0
 - Force cache load on install/upgrade
 - Add man page
+
 * Thu Mar 26 2015 Samuel Karp <skarp@amazon.com> - 1.0-1
 - Re-start Agent on non-terminal exit codes
 - Enable Agent self-updates
 - Cache Agent version 1.0.0
 - Added rollback to cached Agent version for failed updates
+
 * Mon Mar 16 2015 Samuel Karp <skarp@amazon.com> - 0.3-0
 - Migrate to statically-compiled Go binary
+
 * Tue Feb 17 2015 Eric Nordlund <ericn@amazon.com> - 0.2-3
 - Test for existing container agent and force remove it
+
 * Thu Jan 15 2015 Samuel Karp <skarp@amazon.com> - 0.2-2
 - Mount data directory for state persistence
 - Enable JSON-based configuration
+
 * Mon Dec 15 2014 Samuel Karp <skarp@amazon.com> - 0.2-1
 - Naive update functionality
+
 * Thu Dec 11 2014 Samuel Karp <skarp@amazon.com> - 0.2-0
 - Initial version

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -183,10 +183,10 @@ install -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
 %{_sysconfdir}/init/ecs.conf
 %endif
 
-%if %{with systemd}
 %post
 # Symlink the bundled ECS Agent at loadable path.
 ln -sf ecs-agent-v%{bundled_agent_version}.tar %{_cachedir}/ecs/ecs-agent.tar
+%if %{with systemd}
 %systemd_post ecs
 
 %postun

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -136,8 +136,9 @@ Provides:       bundled(golang(golang.org/x/sys/unix))
 Provides:       bundled(golang(golang.org/x/sys/windows))
 
 %description
-ecs-init is a service which may be run to register an EC2 instance as an Amazon
-ECS Container Instance.
+ecs-init supports the initialization and supervision of the Amazon ECS
+container agent, including configuration of cgroups, iptables, and
+required routes among its preparation steps.
 
 %prep
 %setup -c

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -1,9 +1,24 @@
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
 [Unit]
 Description=ECS Agent
 Requires=docker.service
 After=docker.service
 
 [Service]
+Type=simple
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ECS Agent
+Requires=docker.service
+After=docker.service
+
+[Service]
+ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
+ExecStart=/usr/libexec/amazon-ecs-init start
+ExecStop=/usr/libexec/amazon-ecs-init stop
+ExecStopPost=/usr/libexec/amazon-ecs-init post-stop
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/amazon-ecs-init.1
+++ b/scripts/amazon-ecs-init.1
@@ -62,6 +62,7 @@ appropriate \fIExec\fP directives:
 .nf
 # in ecs.service
 [Service]
+Type=simple
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop

--- a/scripts/amazon-ecs-init.1
+++ b/scripts/amazon-ecs-init.1
@@ -1,28 +1,112 @@
-.TH AMAZON-ECS-INIT 1 2015-04-20 AMAZON AMAZON-EC2-CONTAINER-SERVICE
+.\" Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.\"
+.\" Licensed under the Apache License, Version 2.0 (the
+.\" "License"). You may not use this file except in compliance
+.\" with the License. A copy of the License is located at
+.\"
+.\"      http://aws.amazon.com/apache2.0/
+.\"
+.\" or in the "license" file accompanying this file. This file is
+.\" distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+.\" CONDITIONS OF ANY KIND, either express or implied. See the
+.\" License for the specific language governing permissions and
+.\" limitations under the License.
+.TH AMAZON-ECS-INIT 1 2018-06-01 AMAZON AMAZON-ELASTIC-CONTAINER-SERVICE
 .SH NAME
-amazon\-ecs\-init \- ecs\-init is a service which may be run to register an EC2 instance as an Amazon ECS Container Instance.
+amazon\-ecs\-init \- Elastic Container Service container agent supervisor
 .SH SYNOPSIS
 .B amazon\-ecs\-init
 .IR ACTION
 .SH DESCRIPTION
 .B amazon\-ecs\-init
-is software developed to support the Amazon ECS Container Agent (http://github.com/aws/amazon-ecs-agent).
-.B amazon\-ecs\-init
-is packaged for RPM-based systems that utilize Upstart (http://upstart.ubuntu.com) as the init system.
+supports the initialization and supervision of the Amazon ECS
+container agent (http://github.com/aws/amazon-ecs-agent), including
+configuration of cgroups, iptables, and required routes among its
+preparation steps.
 .SH ACTIONS
-.TP
+.TP 16
 .BR pre-start
-Prepare the ECS Agent for starting
-.TP
+Configure the system and load the ECS agent container image
+.TP 16
 .BR start
-Start the ECS Agent and wait for it to stop
-.TP
+Start the ECS agent container and wait for it to stop
+.TP 16
 .BR pre-stop
-Stop the ECS Agent
-.TP
+Stop the ECS agent container
+.TP 16
+.BR stop
+Stop the ECS agent container
+.TP 16
+.BR post-stop
+Cleanup system from ECS agent configuration
+.TP 16
 .BR reload-cache
-Reload the cached image of the ECS Agent into Docker
+Reload the cached ECS agent container image
+.SH INIT SYSTEM USAGE
+.B amazon\-ecs\-init
+is officially supported to run under systemd on Amazon Linux 2 and
+upstart on Amazon Linux 1.
+.SS SYSTEMD
+systemd units are expected to use the
+.BR ACTIONS
+.IR pre-start ,
+.IR start ,
+.IR stop ,
+and
+.IR post-stop
+to manage the lifecycle of the ECS agent.
+
+These \fBACTIONS\fR must be used in the [Service] section with the
+appropriate \fIExec\fP directives:
+.IP
+.nf
+# in ecs.service
+[Service]
+ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
+ExecStart=/usr/libexec/amazon-ecs-init start
+ExecStop=/usr/libexec/amazon-ecs-init stop
+ExecStopPost=/usr/libexec/amazon-ecs-init post-stop
+.fi
+.SS UPSTART
+Upstart jobs are expected to use the
+.BR ACTIONS
+.IR pre-start ,
+.IR start ,
+.IR pre-stop ,
+and
+.IR post-stop
+to manage the lifecycle of the ECS agent.
+
+The directives in the upstart job must align with the above
+\fBACTIONS\fR:
+.IP
+.nf
+# in ecs.conf
+pre-start exec /usr/libexec/amazon-ecs-init pre-start
+exec /usr/libexec/amazon-ecs-init start
+pre-stop exec /usr/libexec/amazon-ecs-init pre-stop
+post-stop exec /usr/libexec/amazon-ecs-init post-stop
+.fi
+.SH TROUBLESHOOTING
+Troubleshooting guidance is provided in the online Amazon ECS
+documentation, please visit
+https://docs.aws.amazon.com/AmazonECS/latest/developerguide/troubleshooting.html
 .SH COPYRIGHT
-Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights
+Reserved.
 .SH LICENSE
 Licensed under the Apache License, Version 2.0.
+.SH NOTES
+.TP
+Amazon ECS Agent \- Documentation
+.nh
+https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_agent.html
+.TP
+Amazon ECS Agent \- Source Repository
+.nh
+https://github.com/aws/amazon-ecs-agent
+.TP
+Amazon ECS Init \- Source Repository
+.nh
+https://github.com/aws/amazon-ecs-init
+.TP

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -44,8 +44,8 @@ else
 	if [[ "$1" != "" ]]; then
 		tags="-tags '$1'"
 	fi
-	CGO_ENABLED=0 go build -a ${tags} -x -ldflags '-s' \
-		   -ldflags "${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
+	CGO_ENABLED=0 go build -a ${tags} -x \
+		   -ldflags "-s ${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
 		   -o "${TOPWD}/amazon-ecs-init"
 fi
 rm -r "${BUILDDIR}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This change wraps the existing `ecs-init` daemon (with minor semantic modifications) with a systemd unit to run under Amazon Linux 2.


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->

Minor modifications have been made to the entrypoints in the `ecs-init` binary to include the `stop` verb to align with systemd semantics surrounding service lifecycle. Though there is no difference from `post-stop` from upstart land, this allows the two to coexist in code if a change in handling is required at a later time.

The updated RPM spec accommodates both Amazon Linux and Amazon Linux 2 (thanks @ilianaw!) and includes a unit file suitable for running `ecs-init` on Amazon Linux 2 (with `systemctl start ecs`).


### Testing
<!-- How was this tested? -->

The RPM was built both for Amazon Linux and Amazon Linux 2 and run in an ECS Cluster with some tasks to confirm no functional differences were present.

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Add Amazon Linux 2 systemd unit to RPM spec

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
