### PR TITLE
Improve ecs systemd unit

### DIFF
--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -16,6 +16,7 @@
 Description=ECS Agent
 Requires=docker.service
 After=docker.service
+After=cloud-final.service
 
 [Service]
 Type=simple

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -20,6 +20,8 @@ After=cloud-final.service
 
 [Service]
 Type=simple
+Restart=on-failure
+RestartSec=10s
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This change ensures `ecs.service` start after `cloud-final.service`, the last cloud-init stage ([see docs][0]), for user data configuration of ecs-init. There are transitive `Requires` and `Wants` from other dependent units (ie: though `docker.service`) that achieve a desired ordering however including `After=cloud-final.service` ensures dependent units' ordering do not change `ecs.service`'s order requirement.

10s delay is added between `amazon-ecs-init` restart attempts. This gives some back off time to restart `ecs-init` (eg: more than 100ms).

[0]: https://cloudinit.readthedocs.io/en/0.7.9/topics/boot.html

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Appropriate systemd unit directives were added.

### Testing
<!-- How was this tested? -->
System starts up with dependencies in the correct order.

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
