### PR TITLE
Allow cgroup mountpoint to be specified by env variable

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -45,6 +45,10 @@ const (
 	// DefaultRegionName is the default region to fall back if the user's region is not a region containing
 	// the agent bucket
 	DefaultRegionName = endpoints.UsEast1RegionID
+
+	// cgroupMountpointEnv is the Environment Variable used to provide
+	// an alternative path to the cgroup mount on the host.
+	cgroupMountpointEnv = "CGROUP_MOUNTPOINT"
 )
 
 var partitionBucketMap = map[string]string{
@@ -145,5 +149,10 @@ func DockerUnixSocket() (string, bool) {
 
 // CgroupMountpoint returns the cgroup mountpoint for the system
 func CgroupMountpoint() string {
+	// Check environment provided path
+	fromEnv := os.Getenv(cgroupMountpointEnv)
+	if fromEnv != "" {
+		return fromEnv
+	}
 	return cgroupMountpoint
 }

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -82,3 +82,36 @@ func TestGetAgentPartitionBucketRegion(t *testing.T) {
 			})
 	}
 }
+
+func TestCgroupMountpoint(t *testing.T) {
+	originalEnv := os.Getenv(cgroupMountpointEnv)
+	defer os.Setenv(cgroupMountpointEnv, originalEnv)
+
+	testcases := []struct {
+		name     string
+		env      string
+		expected string
+	}{
+		{
+			name:     "system default",
+			env:      "",
+			expected: cgroupMountpoint,
+		},
+		{
+			name:     "from environment",
+			env:      "/other/mountpoint/cgroup",
+			expected: "/other/mountpoint/cgroup",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			os.Setenv(cgroupMountpointEnv, testcase.env)
+
+			actual := CgroupMountpoint()
+			if actual != testcase.expected {
+				t.Errorf("Expected CgroupMountpoint to be %q, was %q", testcase.expected, actual)
+			}
+		})
+	}
+}

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -22,6 +22,7 @@ After=cloud-final.service
 Type=simple
 Restart=on-failure
 RestartSec=10s
+Environment=CGROUP_MOUNTPOINT=/sys/fs/cgroup
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This enables users to specify the environment variable `CGROUP_MOUNTPOINT` to direct `ecs-init` to use the provided path instead of the compiled default path.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->
Unit test is added and the service was used on an AL2 instance where a task's cgroup is setup.

New tests cover the changes: <!-- yes|no -->yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
The environment variable is consulted before falling back to the system's compiled in default path.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
