### PR TITLE
Use /etc/ecs/ecs.config for cgroup path with unit default

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -47,8 +47,10 @@ const (
 	DefaultRegionName = endpoints.UsEast1RegionID
 
 	// cgroupMountpointEnv is the Environment Variable used to provide
-	// an alternative path to the cgroup mount on the host.
-	cgroupMountpointEnv = "CGROUP_MOUNTPOINT"
+	// an alternative path to the cgroup mount on the host. This is the
+	// same environment variable as is used by the ECS agent to specify
+	// the cgroup path.
+	cgroupMountpointEnv = "ECS_CGROUP_PATH"
 )
 
 var partitionBucketMap = map[string]string{

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -81,8 +81,6 @@ const (
 	// For more information on setns, please read this manpage:
 	// http://man7.org/linux/man-pages/man2/setns.2.html
 	CapSysAdmin = "SYS_ADMIN"
-	// DefaultCgroupMountpoint is the default mount point for the cgroup subsystem
-	DefaultCgroupMountpoint = "/sys/fs/cgroup"
 	// pluginSocketFilesDir specifies the location of UNIX domain socket files of
 	// Docker plugins
 	pluginSocketFilesDir = "/run/docker/plugins"
@@ -218,6 +216,7 @@ func (c *Client) getContainerConfig() *godocker.Config {
 		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs","none"]`,
 		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
+		"ECS_CGROUP_PATH":                       config.CgroupMountpoint(),
 	}
 
 	// merge in platform-specific environment variables
@@ -274,7 +273,7 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		config.AgentDataDirectory() + ":" + dataDir,
 		config.AgentConfigDirectory() + ":" + config.AgentConfigDirectory(),
 		config.CacheDirectory() + ":" + config.CacheDirectory(),
-		config.CgroupMountpoint() + ":" + DefaultCgroupMountpoint,
+		config.CgroupMountpoint() + ":" + config.CgroupMountpoint(),
 	}
 	binds = append(binds, getDockerPluginDirBinds()...)
 	return createHostConfig(binds)

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -237,6 +237,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)
 	expectKey("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true", envVariables, t)
+	expectKey("ECS_CGROUP_PATH="+config.CgroupMountpoint(), envVariables, t)
 
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)
@@ -258,6 +259,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
 	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
+	expectKey(config.CgroupMountpoint()+":"+config.CgroupMountpoint(), binds, t)
 	expectKey(config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation, binds, t)
 	expectKey(dhclientLibDir+":"+dhclientLibDir+":ro", binds, t)
 	expectKey(dhclientExecutableDir+":"+dhclientExecutableDir+":ro", binds, t)

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [Unit]
-Description=ECS Agent
+Description=Amazon ECS agent
 Requires=docker.service
 After=docker.service
 After=cloud-final.service
@@ -22,7 +22,13 @@ After=cloud-final.service
 Type=simple
 Restart=on-failure
 RestartSec=10s
-Environment=CGROUP_MOUNTPOINT=/sys/fs/cgroup
+Environment=ECS_CGROUP_PATH=/sys/fs/cgroup
+# Environment variable overrides can be placed in the ecs.config file
+# to configure the ECS agent.  Please visit the AWS ECS Documentation
+# for details on the configurable options for the ECS agent:
+#
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html
+EnvironmentFile=-/etc/ecs/ecs.config
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop


### PR DESCRIPTION

### Summary
<!-- What does this pull request do? -->
This enables the use of the unit file and the existing /etc/ecs/ecs.config file to configure the init process as well. With this change, the cgroup mountpoint in and outside the spawned container will match and respect the same environment variable.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
The environment variable is reused from the ECS agent and loaded by the systemd unit when present. Defaults are provided in the unit. 

### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Use `/etc/ecs/ecs.config` to align some settings

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
