### PR TITLE
Add al2 build tag and target in spec

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -45,10 +45,6 @@ const (
 	// DefaultRegionName is the default region to fall back if the user's region is not a region containing
 	// the agent bucket
 	DefaultRegionName = endpoints.UsEast1RegionID
-
-	// cgroupMountpointEnv is the Environment Variable used to provide
-	// an alternative path to the cgroup mount on the host.
-	cgroupMountpointEnv = "CGROUP_MOUNTPOINT"
 )
 
 var partitionBucketMap = map[string]string{
@@ -149,10 +145,5 @@ func DockerUnixSocket() (string, bool) {
 
 // CgroupMountpoint returns the cgroup mountpoint for the system
 func CgroupMountpoint() string {
-	// Check environment provided path
-	fromEnv := os.Getenv(cgroupMountpointEnv)
-	if fromEnv != "" {
-		return fromEnv
-	}
 	return cgroupMountpoint
 }

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -82,36 +82,3 @@ func TestGetAgentPartitionBucketRegion(t *testing.T) {
 			})
 	}
 }
-
-func TestCgroupMountpoint(t *testing.T) {
-	originalEnv := os.Getenv(cgroupMountpointEnv)
-	defer os.Setenv(cgroupMountpointEnv, originalEnv)
-
-	testcases := []struct {
-		name     string
-		env      string
-		expected string
-	}{
-		{
-			name:     "system default",
-			env:      "",
-			expected: cgroupMountpoint,
-		},
-		{
-			name:     "from environment",
-			env:      "/other/mountpoint/cgroup",
-			expected: "/other/mountpoint/cgroup",
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			os.Setenv(cgroupMountpointEnv, testcase.env)
-
-			actual := CgroupMountpoint()
-			if actual != testcase.expected {
-				t.Errorf("Expected CgroupMountpoint to be %q, was %q", testcase.expected, actual)
-			}
-		})
-	}
-}

--- a/ecs-init/config/config_al2.go
+++ b/ecs-init/config/config_al2.go
@@ -1,6 +1,6 @@
-// +build !suse,!ubuntu,!al2
+// +build al2
 
-// Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -15,4 +15,4 @@
 
 package config
 
-const cgroupMountpoint = "/cgroup"
+const cgroupMountpoint = "/sys/fs/cgroup"

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -14,16 +14,18 @@
 
 %if 0%{?amzn} >= 2
 %bcond_without systemd # with
+%global gobuild_tag al2
 %else
 %bcond_with systemd # without
 %global running_semaphore %{_localstatedir}/run/ecs-init.was-running
+%global gobuild_tag %{nil}
 %endif
 %global _cachedir %{_localstatedir}/cache
 %global bundled_agent_version %{version}
 
 Name:           ecs-init
 Version:        1.18.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache 2.0
 Summary:        Amazon Elastic Container Service initialization application
 ExclusiveArch:  x86_64
@@ -144,7 +146,7 @@ required routes among its preparation steps.
 %setup -c
 
 %build
-./scripts/gobuild.sh
+./scripts/gobuild.sh %{gobuild_tag}
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -22,7 +22,6 @@ After=cloud-final.service
 Type=simple
 Restart=on-failure
 RestartSec=10s
-Environment=CGROUP_MOUNTPOINT=/sys/fs/cgroup
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
 ExecStart=/usr/libexec/amazon-ecs-init start
 ExecStop=/usr/libexec/amazon-ecs-init stop


### PR DESCRIPTION
### Summary
The appropriate path is compiled into ecs-init for execution on Amazon
Linux 2 when targeted with the go build tag al2.

NB: This effectively undoes #176 to prefer compiled constants and obsoletes #177 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->


<!-- What does this pull request do? -->


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
A `go build` tag was added to the respective config file with constants and updated the unspecified variants.

### Testing
<!-- How was this tested? -->
RPM builds completed successfully using the appropriate build tag passed to the build script. The unit starts up and sets up task cgroups on an Amazon Linux 2 instance without the environment variable previously present in the unit.

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
