### PR TITLE
Add the attempted download URL to ecs-init error logging

### DIFF
--- a/ecs-init/cache/dependencies.go
+++ b/ecs-init/cache/dependencies.go
@@ -109,7 +109,7 @@ func (d *s3Downloader) downloadFile(fileName string) (string, error) {
 				fileName, bucketDownloader.bucket, bucketDownloader.region)
 			return fileName, nil
 		} else {
-			log.Debugf("Download file %s from bucket %s in region %s failed with error: %v",
+			log.Errorf("Download file %s from bucket %s in region %s failed with error: %v",
 				fileName, bucketDownloader.bucket, bucketDownloader.region, err)
 		}
 	}


### PR DESCRIPTION
### Summary
Added the attempted download URL to the Error logs when the download fails to allow engineers to more quickly determine the nature of the AccessDenied error.
Modified previous download failure message logging level from Debug to Error.

### Implementation details
Added line in the downloadFile() method containing the attempted download URL log statement. 
Changed function in prior failure message from Debugf() to Errorf().

### Testing
<!-- How was this tested? -->
Ran 'make test'.

New tests cover the changes: <!-- yes|no --> No new tests. 

### Description for the changelog
Add the attempted download URL to ecs-init error logging.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
