### PR TITLE
Add systemd support for debian based distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,13 @@ rpm: .rpm-done
 
 ubuntu-trusty:
 	cp packaging/ubuntu-trusty/ecs.conf ecs.conf
-	tar -czf ./amazon-ecs-init_${VERSION}.orig.tar.gz ecs-init ecs.conf scripts README.md
+	cp packaging/ubuntu-trusty/ecs.service ecs.service
+	tar -czf ./amazon-ecs-init_${VERSION}.orig.tar.gz ecs-init ecs.conf ecs.service scripts README.md
 	mkdir -p BUILDROOT
 	cp -r packaging/ubuntu-trusty/debian BUILDROOT/debian
 	cp -r ecs-init BUILDROOT
 	cp packaging/ubuntu-trusty/ecs.conf BUILDROOT
+	cp packaging/ubuntu-trusty/ecs.service BUILDROOT
 	cp -r scripts BUILDROOT
 	cp README.md BUILDROOT
 	cd BUILDROOT && debuild $(shell [ "$(DEB_SIGN)" -ne "0" ] || echo "-uc -us")

--- a/packaging/ubuntu-trusty/debian/amazon-ecs-init.install
+++ b/packaging/ubuntu-trusty/debian/amazon-ecs-init.install
@@ -1,2 +1,3 @@
 amazon-ecs-init usr/sbin/
 ecs.conf etc/init
+ecs.service etc/systemd/system

--- a/packaging/ubuntu-trusty/debian/amazon-ecs-init.postinst
+++ b/packaging/ubuntu-trusty/debian/amazon-ecs-init.postinst
@@ -1,0 +1,5 @@
+if [ -f /bin/systemctl ]; then
+    /bin/systemctl daemon-reload
+    /bin/systemctl enable ecs
+    /bin/systemctl start ecs
+fi

--- a/packaging/ubuntu-trusty/debian/control
+++ b/packaging/ubuntu-trusty/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: http://github.com/aws/amazon-ecs-init
 
 Package: amazon-ecs-init
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, docker-engine (>= 1.6.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, docker-engine (>= 1.6.0) | docker-ce
 Description: Starts the Amazon ECS Agent
  amazon-ecs-init may be run to register an EC2 instance as an Amazon ECS
  Container Instance.

--- a/packaging/ubuntu-trusty/ecs.service
+++ b/packaging/ubuntu-trusty/ecs.service
@@ -1,0 +1,31 @@
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=ECS Agent
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStartPre=/usr/sbin/amazon-ecs-init pre-start
+ExecStart=/usr/sbin/amazon-ecs-init start
+ExecStop=/usr/sbin/amazon-ecs-init stop
+ExecStopPost=/usr/sbin/amazon-ecs-init post-stop
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/ubuntu-trusty/ecs.service
+++ b/packaging/ubuntu-trusty/ecs.service
@@ -24,7 +24,7 @@ Restart=on-failure
 RestartSec=10s
 ExecStartPre=/usr/sbin/amazon-ecs-init pre-start
 ExecStart=/usr/sbin/amazon-ecs-init start
-ExecStop=/usr/sbin/amazon-ecs-init stop
+ExecStop=/usr/sbin/amazon-ecs-init pre-stop
 ExecStopPost=/usr/sbin/amazon-ecs-init post-stop
 
 [Install]


### PR DESCRIPTION
### Summary
Added systemd service and packaging wrappers for debian based package. 

### Testing
Tested on one instance in my internal ECS cluster.

New tests cover the changes: no
There're no tests for packaging.

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
