### PR TITLE
Add prepare-sources hook target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ sources.tgz:
 	cp packaging/amazon-linux-ami/ecs.service ecs.service
 	tar -czf ./sources.tgz ecs-init scripts
 
-sources: sources.tgz
+# Hook to perform preparation steps prior to the sources target.
+prepare-sources::
+
+sources: prepare-sources sources.tgz
 
 .srpm-done: sources.tgz
 	test -e SOURCES || ln -s . SOURCES


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds a hook target for preparing sources prior to the tarball being created.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
An appendable `target-name::` allows additional target actions be appended as needed.

### Testing
<!-- How was this tested? -->

Confirmed target was called prior to `sources.tgz`.

New tests cover the changes: <!-- yes|no -->no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->yes
