### PR TITLE
config, docker: add host /etc/pki dir as mount

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -155,3 +155,11 @@ func HostCertsDirPath() string {
 	}
 	return hostCertsDirPath
 }
+
+// HostPKIDirPath() returns the CA store path on the host
+func HostPKIDirPath() string {
+	if _, err := os.Stat(hostPKIDirPath); err != nil {
+		return ""
+	}
+	return hostPKIDirPath
+}

--- a/ecs-init/config/config_al2.go
+++ b/ecs-init/config/config_al2.go
@@ -18,4 +18,5 @@ package config
 const (
 	cgroupMountpoint = "/sys/fs/cgroup"
 	hostCertsDirPath = "/etc/pki/tls/certs"
+	hostPKIDirPath   = "/etc/pki"
 )

--- a/ecs-init/config/config_unspecified.go
+++ b/ecs-init/config/config_unspecified.go
@@ -18,4 +18,5 @@ package config
 const (
 	cgroupMountpoint = "/cgroup"
 	hostCertsDirPath = "/etc/pki/tls/certs"
+	hostPKIDirPath   = "/etc/pki"
 )

--- a/ecs-init/config/logger.go
+++ b/ecs-init/config/logger.go
@@ -34,7 +34,7 @@ and limitations under the License.
 <seelog type="asyncloop">
 	<outputs formatid="main">
 		<console formatid="console" />
-		<rollingfile filename="` + initLogFile() + `" type="date"
+		<rollingfile filename="`+initLogFile()+`" type="date"
 			 datepattern="2006-01-02-15" archivetype="zip" maxrolls="5" />
 	</outputs>
 	<formats>

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -283,8 +283,8 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 	}
 
 	// for al, al2 add host ssl cert directory mounts
-	if certDir := config.HostCertsDirPath(); certDir != "" {
-		certsPath := certDir + ":" + certDir + readOnly
+	if pkiDir := config.HostPKIDirPath(); pkiDir != "" {
+		certsPath := pkiDir + ":" + pkiDir + readOnly
 		binds = append(binds, certsPath)
 	}
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -251,7 +251,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	// host cert directory configuration.
 	// TODO (adnxn): ideally, these should be behind build flags.
 	// https://github.com/aws/amazon-ecs-init/issues/131
-	if certDir := config.HostCertsDirPath(); certDir == "" {
+	if certDir := config.HostPKIDirPath(); certDir == "" {
 		expectedAgentBinds = expectedAgentBindsSuseUbuntuPlatform
 	}
 


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
mounting root cert store director to agent container so cert store can be accessed by agent binary, additionally we're configuring the specific SSL_CERT_DIR to the paths expected on AL1 and AL2.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
