### PR TITLE
Consume custom instance configuration for GPU support

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -203,3 +203,13 @@ func AgentDockerLogDriverConfiguration() godocker.LogConfig {
 		},
 	}
 }
+
+// InstanceConfigDirectory returns the location on disk for custom instance configuration
+func InstanceConfigDirectory() string {
+	return directoryPrefix + "/usr/lib/ecs"
+}
+
+// InstanceConfigFile returns the location of a file of custom environment variables
+func InstanceConfigFile() string {
+	return InstanceConfigDirectory() + "/ecs.config"
+}

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -63,6 +63,8 @@ const (
 	// be used to override the default value used of
 	// dockerJSONLogMaxFiles for managed containers.
 	dockerJSONLogMaxFilesEnvVar = "ECS_INIT_DOCKER_LOG_FILE_NUM"
+	// GPUSupportEnvVar indicates that the AMI has support for GPU
+	GPUSupportEnvVar = "ECS_ENABLE_GPU_SUPPORT"
 )
 
 var partitionBucketMap = map[string]string{
@@ -206,7 +208,7 @@ func AgentDockerLogDriverConfiguration() godocker.LogConfig {
 
 // InstanceConfigDirectory returns the location on disk for custom instance configuration
 func InstanceConfigDirectory() string {
-	return directoryPrefix + "/usr/lib/ecs"
+	return directoryPrefix + "/var/lib/ecs"
 }
 
 // InstanceConfigFile returns the location of a file of custom environment variables

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -230,8 +230,13 @@ func (c *Client) getContainerConfig() *godocker.Config {
 		envVariables[envKey] = envValue
 	}
 
+	// merge in instance-specific environment variables
+	for envKey, envValue := range c.LoadCustomInstanceEnvVars() {
+		envVariables[envKey] = envValue
+	}
+
 	// merge in user-supplied environment variables
-	for envKey, envValue := range c.loadEnvVariables() {
+	for envKey, envValue := range c.LoadEnvVariables() {
 		envVariables[envKey] = envValue
 	}
 
@@ -246,10 +251,20 @@ func (c *Client) getContainerConfig() *godocker.Config {
 	}
 }
 
-func (c *Client) loadEnvVariables() map[string]string {
+// LoadEnvVariables gets user-supplied environment variables
+func (c *Client) LoadEnvVariables() map[string]string {
+	return c.getEnvVars(config.AgentConfigFile())
+}
+
+// LoadCustomInstanceEnvVars gets custom config set in the instance by Amazon
+func (c *Client) LoadCustomInstanceEnvVars() map[string]string {
+	return c.getEnvVars(config.InstanceConfigFile())
+}
+
+func (c *Client) getEnvVars(filename string) map[string]string {
 	envVariables := make(map[string]string)
 
-	file, err := c.fs.ReadFile(config.AgentConfigFile())
+	file, err := c.fs.ReadFile(filename)
 	if err != nil {
 		return envVariables
 	}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -403,7 +403,7 @@ func TestGetInstanceConfig(t *testing.T) {
 	expectKey("ECS_ENABLE_GPU_SUPPORT=true", envVariables, t)
 }
 
-func TestGetInstanceConfigOverrides(t *testing.T) {
+func TestGetConfigOverrides(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/ecs-init/engine/dependencies.go
+++ b/ecs-init/engine/dependencies.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -36,6 +36,8 @@ type dockerClient interface {
 	RemoveExistingAgentContainer() error
 	StartAgent() (int, error)
 	StopAgent() error
+	LoadEnvVariables() map[string]string
+	LoadCustomInstanceEnvVars() map[string]string
 }
 
 type loopbackRouting interface {

--- a/ecs-init/engine/dependencies.go
+++ b/ecs-init/engine/dependencies.go
@@ -36,8 +36,7 @@ type dockerClient interface {
 	RemoveExistingAgentContainer() error
 	StartAgent() (int, error)
 	StopAgent() error
-	LoadEnvVariables() map[string]string
-	LoadCustomInstanceEnvVars() map[string]string
+	LoadEnvVars() map[string]string
 }
 
 type loopbackRouting interface {

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -207,28 +207,16 @@ func (mr *MockdockerClientMockRecorder) StopAgent() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAgent", reflect.TypeOf((*MockdockerClient)(nil).StopAgent))
 }
 
-// LoadEnvVariables mocks base method
-func (m *MockdockerClient) LoadEnvVariables() map[string]string {
-	ret := m.ctrl.Call(m, "LoadEnvVariables")
+// LoadEnvVars mocks base method
+func (m *MockdockerClient) LoadEnvVars() map[string]string {
+	ret := m.ctrl.Call(m, "LoadEnvVars")
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
-// LoadEnvVariables indicates an expected call of LoadEnvVariables
-func (mr *MockdockerClientMockRecorder) LoadEnvVariables() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVariables", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVariables))
-}
-
-// LoadCustomInstanceEnvVars mocks base method
-func (m *MockdockerClient) LoadCustomInstanceEnvVars() map[string]string {
-	ret := m.ctrl.Call(m, "LoadCustomInstanceEnvVars")
-	ret0, _ := ret[0].(map[string]string)
-	return ret0
-}
-
-// LoadCustomInstanceEnvVars indicates an expected call of LoadCustomInstanceEnvVars
-func (mr *MockdockerClientMockRecorder) LoadCustomInstanceEnvVars() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCustomInstanceEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadCustomInstanceEnvVars))
+// LoadEnvVars indicates an expected call of LoadEnvVars
+func (mr *MockdockerClientMockRecorder) LoadEnvVars() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVars))
 }
 
 // MockloopbackRouting is a mock of loopbackRouting interface

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -207,6 +207,30 @@ func (mr *MockdockerClientMockRecorder) StopAgent() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAgent", reflect.TypeOf((*MockdockerClient)(nil).StopAgent))
 }
 
+// LoadEnvVariables mocks base method
+func (m *MockdockerClient) LoadEnvVariables() map[string]string {
+	ret := m.ctrl.Call(m, "LoadEnvVariables")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// LoadEnvVariables indicates an expected call of LoadEnvVariables
+func (mr *MockdockerClientMockRecorder) LoadEnvVariables() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVariables", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVariables))
+}
+
+// LoadCustomInstanceEnvVars mocks base method
+func (m *MockdockerClient) LoadCustomInstanceEnvVars() map[string]string {
+	ret := m.ctrl.Call(m, "LoadCustomInstanceEnvVars")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// LoadCustomInstanceEnvVars indicates an expected call of LoadCustomInstanceEnvVars
+func (mr *MockdockerClientMockRecorder) LoadCustomInstanceEnvVars() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCustomInstanceEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadCustomInstanceEnvVars))
+}
+
 // MockloopbackRouting is a mock of loopbackRouting interface
 type MockloopbackRouting struct {
 	ctrl     *gomock.Controller

--- a/ecs-init/engine/engine_test.go
+++ b/ecs-init/engine/engine_test.go
@@ -33,8 +33,7 @@ func TestPreStartImageAlreadyCachedAndLoaded(t *testing.T) {
 	mockDocker := NewMockdockerClient(mockCtrl)
 	mockDownloader := NewMockdownloader(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	// Docker reports image is loaded.
 	mockDocker.EXPECT().IsAgentImageLoaded().Return(true, nil)
 	// Agent tarball and state is present
@@ -66,8 +65,7 @@ func TestPreStartReloadNeeded(t *testing.T) {
 	mockDocker := NewMockdockerClient(mockCtrl)
 	mockDownloader := NewMockdownloader(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	// Docker reports image is loaded.
 	mockDocker.EXPECT().IsAgentImageLoaded().Return(true, nil)
 	// Agent tarball and state is present, but requires a reload off of disk
@@ -104,9 +102,7 @@ func TestPreStartImageNotLoadedCached(t *testing.T) {
 	mockLoopbackRouting := NewMockloopbackRouting(mockCtrl)
 	mockRoute := NewMockcredentialsProxyRoute(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
-
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	mockRoute.EXPECT().Create().Return(nil)
 	mockLoopbackRouting.EXPECT().Enable().Return(nil)
 	mockDocker.EXPECT().IsAgentImageLoaded().Return(false, nil)
@@ -136,8 +132,7 @@ func TestPreStartImageNotCached(t *testing.T) {
 	mockDocker := NewMockdockerClient(mockCtrl)
 	mockDownloader := NewMockdownloader(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	mockDocker.EXPECT().IsAgentImageLoaded().Return(false, nil)
 	mockDownloader.EXPECT().AgentCacheStatus().Return(cache.StatusUncached)
 	mockDownloader.EXPECT().DownloadAgent()
@@ -170,10 +165,9 @@ func TestPreStartGPUSetupSuccessful(t *testing.T) {
 	mockDownloader := NewMockdownloader(mockCtrl)
 	mockGPUManager := gpu.NewMockGPUManager(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(map[string]string{
+	mockDocker.EXPECT().LoadEnvVars().Return(map[string]string{
 		"ECS_ENABLE_GPU_SUPPORT": "true",
 	})
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
 	mockGPUManager.EXPECT().Setup().Return(nil)
 	// Docker reports image is loaded.
 	mockDocker.EXPECT().IsAgentImageLoaded().Return(true, nil)
@@ -205,10 +199,9 @@ func TestPreStartGPUSetupError(t *testing.T) {
 	mockDocker := NewMockdockerClient(mockCtrl)
 	mockGPUManager := gpu.NewMockGPUManager(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(map[string]string{
+	mockDocker.EXPECT().LoadEnvVars().Return(map[string]string{
 		"ECS_ENABLE_GPU_SUPPORT": "true",
 	})
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
 	mockGPUManager.EXPECT().Setup().Return(errors.New("gpu setup failed"))
 	engine := &Engine{
 		docker:           mockDocker,
@@ -442,8 +435,7 @@ func TestPrestartLoopbackRoutingNotEnabled(t *testing.T) {
 	mockDownloader := NewMockdownloader(mockCtrl)
 	mockLoopbackRouting := NewMockloopbackRouting(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	mockLoopbackRouting.EXPECT().Enable().Return(fmt.Errorf("sysctl not found"))
 	mockRoute := NewMockcredentialsProxyRoute(mockCtrl)
 
@@ -467,8 +459,7 @@ func TestPrestartCredentialsProxyRouteNotCreated(t *testing.T) {
 	mockDownloader := NewMockdownloader(mockCtrl)
 	mockLoopbackRouting := NewMockloopbackRouting(mockCtrl)
 
-	mockDocker.EXPECT().LoadCustomInstanceEnvVars().Return(nil)
-	mockDocker.EXPECT().LoadEnvVariables().Return(nil)
+	mockDocker.EXPECT().LoadEnvVars().Return(nil)
 	mockLoopbackRouting.EXPECT().Enable().Return(nil)
 	mockRoute := NewMockcredentialsProxyRoute(mockCtrl)
 	mockRoute.EXPECT().Create().Return(fmt.Errorf("iptables not found"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Custom GPU AMI configuration `ECS_ENABLE_GPU_SUPPORT` to be set at `/usr/lib/ecs/ecs.config` 
This will be further used for getting GPU information in the instance 
Note: This can be overridden by user config at `/etc/ecs/ecs.config`

### Testing
<!-- How was this tested? -->

New tests cover the changes: yes
### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
