### PR TITLE
enable cgo for nvidia code

### DIFF
--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -37,14 +37,14 @@ mkdir -p "${SRCPATH}"
 ln -s "${TOPWD}/ecs-init" "${SRCPATH}"
 cd "${SRCPATH}/ecs-init"
 if [[ "$1" == "dev" ]]; then
-	go build -tags 'development' -ldflags "${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
+	CGO_ENABLED=1 CGO_LDFLAGS_ALLOW='-Wl,--unresolved-symbols=ignore-in-object-files' go build -tags 'development' -ldflags "${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
 	   -o "${TOPWD}/amazon-ecs-init"
 else
 	tags=""
 	if [[ "$1" != "" ]]; then
 		tags="-tags '$1'"
 	fi
-	CGO_ENABLED=0 go build -a ${tags} -x \
+	CGO_ENABLED=1 CGO_LDFLAGS_ALLOW='-Wl,--unresolved-symbols=ignore-in-object-files' go build -a ${tags} -x \
 		   -ldflags "-s ${VERSION_FLAG} ${GIT_HASH_FLAG} ${GIT_DIRTY_FLAG}" \
 		   -o "${TOPWD}/amazon-ecs-init"
 fi


### PR DESCRIPTION


### Summary
address build error 
`go build github.com/aws/amazon-ecs-init/ecs-init/vendor/github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml: invalid flag in #cgo LDFLAGS: -Wl,--unresolved-symbols=ignore-in-object-files`


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
