### PR TITLE
mount gpu info dir only for GPU supported instances

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -311,14 +311,19 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 		config.CgroupMountpoint() + ":" + DefaultCgroupMountpoint,
 		// bind mount instance config dir
 		config.InstanceConfigDirectory() + ":" + config.InstanceConfigDirectory(),
-		// bind mount gpu info dir
-		gpu.GPUInfoDirPath + ":" + gpu.GPUInfoDirPath,
 	}
 
 	// for al, al2 add host ssl cert directory mounts
 	if pkiDir := config.HostPKIDirPath(); pkiDir != "" {
 		certsPath := pkiDir + ":" + pkiDir + readOnly
 		binds = append(binds, certsPath)
+	}
+
+	for key, val := range c.LoadEnvVars() {
+		if key == config.GPUSupportEnvVar && val == "true" {
+			// bind mount gpu info dir
+			binds = append(binds, gpu.GPUInfoDirPath+":"+gpu.GPUInfoDirPath)
+		}
 	}
 
 	binds = append(binds, getDockerPluginDirBinds()...)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
same as title


### Implementation details
check if the instance config or env var `ECS_ENABLE_GPU_SUPPORT` is set to true and mount gpu info dir into agent container 



### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
