### PR TITLE
send GPU instance config only when GPUs are present

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -253,6 +253,11 @@ func (c *Client) LoadEnvVars() map[string]string {
 	envVariables := make(map[string]string)
 	// merge in instance-specific environment variables
 	for envKey, envValue := range c.loadCustomInstanceEnvVars() {
+		if envKey == config.GPUSupportEnvVar && envValue == "true" {
+			if !nvidiaGPUDevicesPresent() {
+				continue
+			}
+		}
 		envVariables[envKey] = envValue
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
add GPU instance config variable `ECS_ENABLE_GPU_SUPPORT` to agent container only when GPU devices are present in the instance


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
Manual testing:
Non GPU instance:
```
$ docker inspect ecs-agent | grep "ECS_ENABLE_GPU_SUPPORT"
[ec2-user@ip-172-31-18-88 ~]$
```
GPU instance:
```
$ docker inspect ecs-agent | grep "ECS_ENABLE_GPU_SUPPORT"
                "ECS_ENABLE_GPU_SUPPORT=true",
```

New tests cover the changes: yes

### Description for the changelog
N/A


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes