### PR TITLE
remove references to DHClient

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -127,12 +127,6 @@ func AgentDataDirectory() string {
 	return directoryPrefix + "/var/lib/ecs/data"
 }
 
-// AgentDHClientLeasesDirectory returns the location on disk where dhclient
-// leases information is tracked for ENIs attached to tasks
-func AgentDHClientLeasesDirectory() string {
-	return directoryPrefix + "/var/lib/ecs/dhclient"
-}
-
 // CacheDirectory returns the location on disk where Agent images should be cached
 func CacheDirectory() string {
 	return directoryPrefix + "/var/cache/ecs"

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -44,16 +44,6 @@ const (
 	// defaultDockerEndpoint is set to /var/run instead of /var/run/docker.sock
 	// in case /var/run/docker.sock is deleted and recreated outside the container
 	defaultDockerEndpoint = "/var/run"
-	// dhclientLeasesLocation specifies the location where dhclient leases
-	// information is tracked in the Agent container
-	dhclientLeasesLocation = "/var/lib/dhclient"
-	// dhclientLibDir specifies the location of shared libraries on the
-	// host and in the Agent container required for the execution of the dhclient
-	// executable
-	dhclientLibDir = "/lib64"
-	// dhclientExecutableDir specifies the location of the dhclient
-	// executable on the  host and in the Agent container
-	dhclientExecutableDir = "/sbin"
 	// networkMode specifies the networkmode to create the agent container
 	networkMode = "host"
 	// usernsMode specifies the userns mode to create the agent container

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -28,8 +28,8 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	expectedAgentBindsUnspecifiedPlatform = 15
-	expectedAgentBindsSuseUbuntuPlatform  = 13
+	expectedAgentBindsUnspecifiedPlatform = 12
+	expectedAgentBindsSuseUbuntuPlatform  = 10
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -272,9 +272,6 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
 	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
-	expectKey(config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation, binds, t)
-	expectKey(dhclientLibDir+":"+dhclientLibDir+":ro", binds, t)
-	expectKey(dhclientExecutableDir+":"+dhclientExecutableDir+":ro", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)
 	}

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -31,14 +31,9 @@ func getPlatformSpecificEnvVariables() map[string]string {
 }
 
 // createHostConfig creates the host config for the ECS Agent container
-// It mounts dhclient executable, leases and pid file directories when built
-// for Amazon Linux AMI
+// It mounts leases and pid file directories when built for Amazon Linux AMI
 func createHostConfig(binds []string) *godocker.HostConfig {
-	binds = append(binds,
-		config.ProcFS+":"+hostProcDir+readOnly,
-		config.AgentDHClientLeasesDirectory()+":"+dhclientLeasesLocation,
-		dhclientLibDir+":"+dhclientLibDir+readOnly,
-		dhclientExecutableDir+":"+dhclientExecutableDir+readOnly)
+	binds = append(binds, config.ProcFS+":"+hostProcDir+readOnly)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 

--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -55,7 +55,6 @@ Requires:       upstart
 Requires:       iptables
 Requires:       docker >= 17.06.2ce
 Requires:       procps
-Requires:       dhclient
 
 # The following 'Provides' lists the vendored dependencies bundled in
 # and used to produce the ecs-init package. As dependencies are added
@@ -172,7 +171,7 @@ echo 2 > %{buildroot}%{_cachedir}/ecs/state
 # Add a bundled ECS container agent image
 install %{agent_image} %{buildroot}%{_cachedir}/ecs/
 
-mkdir -p %{buildroot}%{_sharedstatedir}/ecs/{data,dhclient}
+mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 
 %if %{with systemd}
 install -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
@@ -189,7 +188,6 @@ install -D %{SOURCE1} %{buildroot}%{_sysconfdir}/init/ecs.conf
 %{_cachedir}/ecs/%{basename:%{agent_image}}
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
-%ghost %{_sharedstatedir}/ecs/dhclient
 
 %if %{with systemd}
 %{_unitdir}/ecs.service


### PR DESCRIPTION
### Summary
https://github.com/aws/amazon-ecs-init/issues/209
This change removes the unused DHClient import and its references in ecs-init.

### Testing
This was tested on a fresh ECS Optimized Amazon Linux EC2 instance; I ran unit tests against my changes using the make `gotest` target.

I changed docker_test.go to reflect the updated binds and bind count.

### Description for the changelog
Feature - Remove the unused DHClient import and references


