### PR TITLE
Add binding for agent container to be able to run iptables.

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -84,6 +84,17 @@ const (
 	// pluginSpecFilesUsrDir specifies one of the locations of spec or json files
 	// of Docker plugins
 	pluginSpecFilesUsrDir = "/usr/lib/docker/plugins"
+	// iptablesExecutableDir specifies the location of the iptable
+	// executable on the host and in the Agent container
+	iptablesExecutableDir = "/sbin"
+	// iptablesLibDir specifies the location of shared libraries on the
+	// host and in the Agent container required for the execution of the iptables
+	// executable
+	iptablesLibDir = "/lib64"
+	// iptablesUsrLibDir specifies the location of shared libraries on the
+	// host and in the Agent container required for the execution of the iptables
+	// executable. Some OS like AL2 moved lib64 to /usr/lib64
+	iptablesUsrLibDir = "/usr/lib64"
 )
 
 var pluginDirs = []string{

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -28,8 +28,8 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	expectedAgentBindsUnspecifiedPlatform = 12
-	expectedAgentBindsSuseUbuntuPlatform  = 10
+	expectedAgentBindsUnspecifiedPlatform = 15
+	expectedAgentBindsSuseUbuntuPlatform  = 13
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -272,6 +272,9 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
 	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
+	expectKey(iptablesUsrLibDir+":"+iptablesUsrLibDir+":ro", binds, t)
+	expectKey(iptablesLibDir+":"+iptablesLibDir+":ro", binds, t)
+	expectKey(iptablesExecutableDir+":"+iptablesExecutableDir+":ro", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)
 	}

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -33,7 +33,12 @@ func getPlatformSpecificEnvVariables() map[string]string {
 // createHostConfig creates the host config for the ECS Agent container
 // It mounts leases and pid file directories when built for Amazon Linux AMI
 func createHostConfig(binds []string) *godocker.HostConfig {
-	binds = append(binds, config.ProcFS+":"+hostProcDir+readOnly)
+	binds = append(binds,
+		config.ProcFS+":"+hostProcDir+readOnly,
+		iptablesUsrLibDir+":"+iptablesUsrLibDir+readOnly,
+		iptablesLibDir+":"+iptablesLibDir+readOnly,
+		iptablesExecutableDir+":"+iptablesExecutableDir+readOnly,
+	)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add binding /sbin, /usr/lib64, /lib64 to support iptable command for appmesh cni plugin

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
