### PR TITLE
Adding "/lib" and "/usr/lib" to the binds

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -87,14 +87,14 @@ const (
 	// iptablesExecutableDir specifies the location of the iptable
 	// executable on the host and in the Agent container
 	iptablesExecutableDir = "/sbin"
-	// iptablesLibDir specifies the location of shared libraries on the
+
+	// the following libDirs  specify the location of shared libraries on the
 	// host and in the Agent container required for the execution of the iptables
-	// executable
-	iptablesLibDir = "/lib64"
-	// iptablesUsrLibDir specifies the location of shared libraries on the
-	// host and in the Agent container required for the execution of the iptables
-	// executable. Some OS like AL2 moved lib64 to /usr/lib64
-	iptablesUsrLibDir = "/usr/lib64"
+	// executable. Some OS like AL2 moved lib64 to /usr/lib64 (and lib to /usr/lib)
+	iptablesLibDir = "/lib"
+	iptablesUsrLibDir = "/usr/lib"
+	iptablesLib64Dir = "/lib64"
+	iptablesUsrLib64Dir = "/usr/lib64"
 )
 
 var pluginDirs = []string{

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -28,8 +28,8 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	expectedAgentBindsUnspecifiedPlatform = 15
-	expectedAgentBindsSuseUbuntuPlatform  = 13
+	expectedAgentBindsUnspecifiedPlatform = 17
+	expectedAgentBindsSuseUbuntuPlatform  = 15
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -274,6 +274,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
 	expectKey(iptablesUsrLibDir+":"+iptablesUsrLibDir+":ro", binds, t)
 	expectKey(iptablesLibDir+":"+iptablesLibDir+":ro", binds, t)
+	expectKey(iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+":ro", binds, t)
+	expectKey(iptablesLib64Dir+":"+iptablesLib64Dir+":ro", binds, t)
 	expectKey(iptablesExecutableDir+":"+iptablesExecutableDir+":ro", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -37,6 +37,8 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		config.ProcFS+":"+hostProcDir+readOnly,
 		iptablesUsrLibDir+":"+iptablesUsrLibDir+readOnly,
 		iptablesLibDir+":"+iptablesLibDir+readOnly,
+		iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+readOnly,
+		iptablesLib64Dir+":"+iptablesLib64Dir+readOnly,
 		iptablesExecutableDir+":"+iptablesExecutableDir+readOnly,
 	)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
In order for iptables to execute, we also need /lib and /usr/lib to be mounted to the agent container.


If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
Manually tested on AL2 Arm a1.2xlarge

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
