### PR TITLE
Add splunk to log driver defaults

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -218,7 +218,7 @@ func (c *Client) getContainerConfig() *godocker.Config {
 		"ECS_AGENT_CONFIG_FILE_PATH":            config.AgentJSONConfigFile(),
 		"ECS_UPDATE_DOWNLOAD_DIR":               config.CacheDirectory(),
 		"ECS_UPDATES_ENABLED":                   "true",
-		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs","none"]`,
+		"ECS_AVAILABLE_LOGGING_DRIVERS":         `["json-file","syslog","awslogs","splunk","none"]`,
 		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 	}

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -237,7 +237,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_AGENT_CONFIG_FILE_PATH="+config.AgentJSONConfigFile(), envVariables, t)
 	expectKey("ECS_UPDATE_DOWNLOAD_DIR="+config.CacheDirectory(), envVariables, t)
 	expectKey("ECS_UPDATES_ENABLED=true", envVariables, t)
-	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs","none"]`,
+	expectKey(`ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","syslog","awslogs","splunk","none"]`,
 		envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This change adds splunk as a log driver available by default.

### Implementation details
"splunk" is added to the default environment variable.

This can be overridden if the ECS_AVAILABLE_LOGGING_DRIVERS variable is set in ecs.config.

```
# eg, if this is in the ecs.config file, splunk will not be enabled
ECS_AVAILABLE_LOGGING_DRIVERS=["awslogs"]
```


### Testing
<!-- How was this tested? -->
WIP

New tests cover the changes: modified existing test

### Description for the changelog

Add splunk to default log driver list


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
