### PR TITLE
Fix destination path in docker socket bind mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ static:
 	./scripts/gobuild.sh
 
 gotest:
-	go test -short -v -cover ./...
+	go test -count=1 -short -v -cover ./...
 
 test: generate lint gotest
 

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -69,6 +69,9 @@ const (
 	dockerJSONLogMaxFilesEnvVar = "ECS_INIT_DOCKER_LOG_FILE_NUM"
 	// GPUSupportEnvVar indicates that the AMI has support for GPU
 	GPUSupportEnvVar = "ECS_ENABLE_GPU_SUPPORT"
+
+	// DockerHostEnvVar is the environment variable that specifies the location of the Docker daemon socket.
+	DockerHostEnvVar = "DOCKER_HOST"
 )
 
 // partitionBucketRegion provides the "partitional" bucket region
@@ -165,9 +168,9 @@ func DesiredImageLocatorFile() string {
 	return CacheDirectory() + "/desired-image"
 }
 
-// DockerUnixSocket returns the docker socket endpoint and whether it's read from DOCKER_HOST
+// DockerUnixSocket returns the docker socket endpoint and whether it's read from DockerHostEnvVar
 func DockerUnixSocket() (string, bool) {
-	if dockerHost := os.Getenv("DOCKER_HOST"); strings.HasPrefix(dockerHost, UnixSocketPrefix) {
+	if dockerHost := os.Getenv(DockerHostEnvVar); strings.HasPrefix(dockerHost, UnixSocketPrefix) {
 		return strings.TrimPrefix(dockerHost, UnixSocketPrefix), true
 	}
 	// return /var/run instead of /var/run/docker.sock, in case the /var/run/docker.sock is deleted and recreated

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -44,7 +44,9 @@ const (
 	hostProcDir = "/host/proc"
 	// defaultDockerEndpoint is set to /var/run instead of /var/run/docker.sock
 	// in case /var/run/docker.sock is deleted and recreated outside the container
-	defaultDockerEndpoint = "/var/run"
+	defaultDockerEndpoint   = "/var/run"
+	defaultDockerSocketPath = "/var/run/docker.sock"
+
 	// networkMode specifies the networkmode to create the agent container
 	networkMode = "host"
 	// usernsMode specifies the userns mode to create the agent container
@@ -194,11 +196,13 @@ func (c *Client) findAgentContainer() (string, error) {
 
 // StartAgent starts the Agent in Docker and returns the exit code from the container
 func (c *Client) StartAgent() (int, error) {
-	hostConfig := c.getHostConfig()
+	envVarsFromFiles := c.LoadEnvVars()
+
+	hostConfig := c.getHostConfig(envVarsFromFiles)
 
 	container, err := c.docker.CreateContainer(godocker.CreateContainerOptions{
 		Name:       config.AgentContainerName,
-		Config:     c.getContainerConfig(),
+		Config:     c.getContainerConfig(envVarsFromFiles),
 		HostConfig: hostConfig,
 	})
 	if err != nil {
@@ -211,7 +215,7 @@ func (c *Client) StartAgent() (int, error) {
 	return c.docker.WaitContainer(container.ID)
 }
 
-func (c *Client) getContainerConfig() *godocker.Config {
+func (c *Client) getContainerConfig(envVarsFromFiles map[string]string) *godocker.Config {
 	// default environment variables
 	envVariables := map[string]string{
 		"ECS_LOGFILE":                           logDir + "/" + config.AgentLogFile,
@@ -235,9 +239,7 @@ func (c *Client) getContainerConfig() *godocker.Config {
 		envVariables[envKey] = envValue
 	}
 
-	envVars := c.LoadEnvVars()
-
-	for key, val := range envVars {
+	for key, val := range envVarsFromFiles {
 		envVariables[key] = val
 	}
 
@@ -327,15 +329,11 @@ func generateLabelMap(jsonBlock string) (map[string]string, error) {
 	return out, err
 }
 
-func (c *Client) getHostConfig() *godocker.HostConfig {
-	dockerEndpointAgent := defaultDockerEndpoint
-	dockerUnixSocketSourcePath, fromEnv := config.DockerUnixSocket()
-	if fromEnv {
-		dockerEndpointAgent = "/var/run/docker.sock"
-	}
+func (c *Client) getHostConfig(envVarsFromFiles map[string]string) *godocker.HostConfig {
+	dockerSocketBind := getDockerSocketBind(envVarsFromFiles)
 
 	binds := []string{
-		dockerUnixSocketSourcePath + ":" + dockerEndpointAgent,
+		dockerSocketBind,
 		config.LogDirectory() + ":" + logDir,
 		config.AgentDataDirectory() + ":" + dataDir,
 		config.AgentConfigDirectory() + ":" + config.AgentConfigDirectory(),
@@ -364,6 +362,37 @@ func (c *Client) getHostConfig() *godocker.HostConfig {
 	return createHostConfig(binds)
 }
 
+// getDockerSocketBind returns the bind for Docker socket.
+// Value for the bind is as follow:
+// 1. DOCKER_HOST (as in os.Getenv) not set: source /var/run, dest /var/run
+// 2. DOCKER_HOST (as in os.Getenv) set: source DOCKER_HOST (as in os.Getenv, trim unix:// prefix),
+//   dest DOCKER_HOST (as in /etc/ecs/ecs.config, trim unix:// prefix)
+//
+// On AL2, the value from os.Getenv is the same as the one from /etc/ecs/ecs.config, but on AL1 they might be different, which
+// is why I distinguish the two.
+func getDockerSocketBind(envVarsFromFiles map[string]string) string {
+	dockerEndpointAgent := defaultDockerEndpoint
+	dockerUnixSocketSourcePath, fromEnv := config.DockerUnixSocket()
+	if fromEnv {
+		if dockerEndpointFromConfig, ok := envVarsFromFiles[config.DockerHostEnvVar]; ok && strings.HasPrefix(dockerEndpointFromConfig, config.UnixSocketPrefix) {
+			dockerEndpointAgent = strings.TrimPrefix(dockerEndpointFromConfig, config.UnixSocketPrefix)
+		} else {
+			dockerEndpointAgent = defaultDockerSocketPath
+		}
+	}
+
+	return dockerUnixSocketSourcePath + ":" + dockerEndpointAgent
+}
+
+// getDockerPluginDirBinds returns the binds for Docker plugin directories.
+func getDockerPluginDirBinds() []string {
+	var pluginBinds []string
+	for _, pluginDir := range pluginDirs {
+		pluginBinds = append(pluginBinds, pluginDir+":"+pluginDir+readOnly)
+	}
+	return pluginBinds
+}
+
 // nvidiaGPUDevicesPresent checks if nvidia GPU devices are present in the instance
 func nvidiaGPUDevicesPresent() bool {
 	matches, err := MatchFilePatternForGPU(gpu.NvidiaGPUDeviceFilePattern)
@@ -381,14 +410,6 @@ var MatchFilePatternForGPU = FilePatternMatchForGPU
 
 func FilePatternMatchForGPU(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
-}
-
-func getDockerPluginDirBinds() []string {
-	var pluginBinds []string
-	for _, pluginDir := range pluginDirs {
-		pluginBinds = append(pluginBinds, pluginDir+":"+pluginDir+readOnly)
-	}
-	return pluginBinds
 }
 
 // StopAgent stops the Agent in docker if one is running


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Previously, the destination path of the docker socket bind mount is hardcoded to `/var/run/docker.sock`. However, when DOCKER_HOST is specified in `/etc/ecs/ecs.config`, the agent will ping the one specified here, which can be a value different from `unix:///var/run/docker.sock`. So, if customer is having a docker socket at a different path, they are not able to let the agent use it by specifying DOCKER_HOST. This mostly affects AL2 since on AL2 the values from `/etc/ecs/ecs.config` are also loaded as envs for ecs-init, while on AL1 the bind mount is normally just `/var/run:/var/run` (see comments above `getDockerSocketBind` for specific details).

This PR fixes this issue by specifying the destination path to match the one specified in `/etc/ecs/ecs.config` (if any).



### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Fixed the destination path. Did some refactoring in order to allow both`getHostConfig` and `getContainerConfig` to use the content in `/etc/ecs/ecs.config`.


### Testing
<!-- How was this tested? -->
Manually built ecs-init and tested for both AL1 and AL2 with a docker socket at a custom location specified by `DOCKER_HOST`.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
