### PR TITLE
Don't fail the service when stopping a stopped agent

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -423,5 +423,12 @@ func (c *Client) StopAgent() error {
 		return nil
 	}
 	stopContainerTimeoutSeconds := uint(10)
-	return c.docker.StopContainer(id, stopContainerTimeoutSeconds)
+	err = c.docker.StopContainer(id, stopContainerTimeoutSeconds)
+	if err != nil {
+		if _, ok := err.(*godocker.ContainerNotRunning); ok {
+			log.Info("Agent is already stopped")
+			return nil
+		}
+	}
+	return err
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix https://github.com/aws/amazon-ecs-init/issues/227. The cause of the issue is that, on AL1, after the agent container stops, we don't try to stop it again (since it's in pre-stop), but on AL2, afterh the agent stops, we try to stop it again and fail (get a container not running error from Docker) since the pre-stop corresponds to the stop action of the systemd unit on AL2 (https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/ecs-init.go#L101-L104). The failure causes the service to be restarted.

Fixing this behavior on AL2 by not failing the stop step when the agent container is not running.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Check stop container error from docker. if it's of type `ContainerNotRunning`, exits successfully.


### Testing
<!-- How was this tested? -->
Unit test added (combined all the unit tests for `(c *Client) StopAgent()` together).

Manually built AL1 and AL2 rpm and verified that for both case: (1)  the agent remains stopped after stopping the job/service; (2) the agent remains stopped after the agent exits with 0.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
