### PR TITLE
capture a fixed tail of container logs when removing a container

### DIFF
--- a/ecs-init/Gopkg.lock
+++ b/ecs-init/Gopkg.lock
@@ -167,11 +167,12 @@
   version = "v1.27.0"
 
 [[projects]]
-  digest = "1:b9dd62eb71d308d6c4b44af0bae869174975b40baab2ccd65724cefcdb561d55"
+  digest = "1:be408f349cae090a7c17a279633d6e62b00068e64af66a582cae0983de8890ea"
   name = "github.com/golang/mock"
   packages = ["gomock"]
   pruneopts = "UT"
-  revision = "58cd061d09382b6011f84c1291ebe50ef2e25bab"
+  revision = "9fa652df1129bef0e734c9cf9bf6dbae9ef3b9fa"
+  version = "1.3.1"
 
 [[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"

--- a/ecs-init/Gopkg.toml
+++ b/ecs-init/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/golang/mock"
-  revision = "58cd061d09382b6011f84c1291ebe50ef2e25bab"
+  version = "1.3.1"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/ecs-init/cache/dependencies_mocks.go
+++ b/ecs-init/cache/dependencies_mocks.go
@@ -52,6 +52,7 @@ func (m *Mocks3API) EXPECT() *Mocks3APIMockRecorder {
 
 // Download mocks base method
 func (m *Mocks3API) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{w, input}
 	for _, a := range options {
 		varargs = append(varargs, a)
@@ -64,6 +65,7 @@ func (m *Mocks3API) Download(w io.WriterAt, input *s3.GetObjectInput, options ..
 
 // Download indicates an expected call of Download
 func (mr *Mocks3APIMockRecorder) Download(w, input interface{}, options ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{w, input}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*Mocks3API)(nil).Download), varargs...)
 }
@@ -93,16 +95,19 @@ func (m *Mocks3DownloaderAPI) EXPECT() *Mocks3DownloaderAPIMockRecorder {
 
 // addBucketDownloader mocks base method
 func (m *Mocks3DownloaderAPI) addBucketDownloader(bucketDownloader *s3BucketDownloader) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "addBucketDownloader", bucketDownloader)
 }
 
 // addBucketDownloader indicates an expected call of addBucketDownloader
 func (mr *Mocks3DownloaderAPIMockRecorder) addBucketDownloader(bucketDownloader interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addBucketDownloader", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).addBucketDownloader), bucketDownloader)
 }
 
 // downloadFile mocks base method
 func (m *Mocks3DownloaderAPI) downloadFile(fileName string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "downloadFile", fileName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -111,6 +116,7 @@ func (m *Mocks3DownloaderAPI) downloadFile(fileName string) (string, error) {
 
 // downloadFile indicates an expected call of downloadFile
 func (mr *Mocks3DownloaderAPIMockRecorder) downloadFile(fileName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "downloadFile", reflect.TypeOf((*Mocks3DownloaderAPI)(nil).downloadFile), fileName)
 }
 
@@ -139,6 +145,7 @@ func (m *MockfileSystem) EXPECT() *MockfileSystemMockRecorder {
 
 // MkdirAll mocks base method
 func (m *MockfileSystem) MkdirAll(path string, perm os.FileMode) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -146,11 +153,13 @@ func (m *MockfileSystem) MkdirAll(path string, perm os.FileMode) error {
 
 // MkdirAll indicates an expected call of MkdirAll
 func (mr *MockfileSystemMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockfileSystem)(nil).MkdirAll), path, perm)
 }
 
 // TempFile mocks base method
 func (m *MockfileSystem) TempFile(dir, prefix string) (*os.File, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempFile", dir, prefix)
 	ret0, _ := ret[0].(*os.File)
 	ret1, _ := ret[1].(error)
@@ -159,21 +168,25 @@ func (m *MockfileSystem) TempFile(dir, prefix string) (*os.File, error) {
 
 // TempFile indicates an expected call of TempFile
 func (mr *MockfileSystemMockRecorder) TempFile(dir, prefix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockfileSystem)(nil).TempFile), dir, prefix)
 }
 
 // Remove mocks base method
 func (m *MockfileSystem) Remove(path string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Remove", path)
 }
 
 // Remove indicates an expected call of Remove
 func (mr *MockfileSystemMockRecorder) Remove(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockfileSystem)(nil).Remove), path)
 }
 
 // TeeReader mocks base method
 func (m *MockfileSystem) TeeReader(r io.Reader, w io.Writer) io.Reader {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TeeReader", r, w)
 	ret0, _ := ret[0].(io.Reader)
 	return ret0
@@ -181,11 +194,13 @@ func (m *MockfileSystem) TeeReader(r io.Reader, w io.Writer) io.Reader {
 
 // TeeReader indicates an expected call of TeeReader
 func (mr *MockfileSystemMockRecorder) TeeReader(r, w interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeeReader", reflect.TypeOf((*MockfileSystem)(nil).TeeReader), r, w)
 }
 
 // Copy mocks base method
 func (m *MockfileSystem) Copy(dst io.Writer, src io.Reader) (int64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy", dst, src)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
@@ -194,11 +209,13 @@ func (m *MockfileSystem) Copy(dst io.Writer, src io.Reader) (int64, error) {
 
 // Copy indicates an expected call of Copy
 func (mr *MockfileSystemMockRecorder) Copy(dst, src interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockfileSystem)(nil).Copy), dst, src)
 }
 
 // Rename mocks base method
 func (m *MockfileSystem) Rename(oldpath, newpath string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", oldpath, newpath)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -206,11 +223,13 @@ func (m *MockfileSystem) Rename(oldpath, newpath string) error {
 
 // Rename indicates an expected call of Rename
 func (mr *MockfileSystemMockRecorder) Rename(oldpath, newpath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockfileSystem)(nil).Rename), oldpath, newpath)
 }
 
 // ReadAll mocks base method
 func (m *MockfileSystem) ReadAll(r io.Reader) ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAll", r)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -219,11 +238,13 @@ func (m *MockfileSystem) ReadAll(r io.Reader) ([]byte, error) {
 
 // ReadAll indicates an expected call of ReadAll
 func (mr *MockfileSystemMockRecorder) ReadAll(r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockfileSystem)(nil).ReadAll), r)
 }
 
 // Open mocks base method
 func (m *MockfileSystem) Open(name string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
@@ -232,11 +253,13 @@ func (m *MockfileSystem) Open(name string) (io.ReadCloser, error) {
 
 // Open indicates an expected call of Open
 func (mr *MockfileSystemMockRecorder) Open(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockfileSystem)(nil).Open), name)
 }
 
 // Stat mocks base method
 func (m *MockfileSystem) Stat(name string) (fileSizeInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
 	ret0, _ := ret[0].(fileSizeInfo)
 	ret1, _ := ret[1].(error)
@@ -245,11 +268,13 @@ func (m *MockfileSystem) Stat(name string) (fileSizeInfo, error) {
 
 // Stat indicates an expected call of Stat
 func (mr *MockfileSystemMockRecorder) Stat(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockfileSystem)(nil).Stat), name)
 }
 
 // Base mocks base method
 func (m *MockfileSystem) Base(path string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Base", path)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -257,11 +282,13 @@ func (m *MockfileSystem) Base(path string) string {
 
 // Base indicates an expected call of Base
 func (mr *MockfileSystemMockRecorder) Base(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Base", reflect.TypeOf((*MockfileSystem)(nil).Base), path)
 }
 
 // WriteFile mocks base method
 func (m *MockfileSystem) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", filename, data, perm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -269,6 +296,7 @@ func (m *MockfileSystem) WriteFile(filename string, data []byte, perm os.FileMod
 
 // WriteFile indicates an expected call of WriteFile
 func (mr *MockfileSystemMockRecorder) WriteFile(filename, data, perm interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockfileSystem)(nil).WriteFile), filename, data, perm)
 }
 
@@ -297,6 +325,7 @@ func (m *MockfileSizeInfo) EXPECT() *MockfileSizeInfoMockRecorder {
 
 // Size mocks base method
 func (m *MockfileSizeInfo) Size() int64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
 	ret0, _ := ret[0].(int64)
 	return ret0
@@ -304,6 +333,7 @@ func (m *MockfileSizeInfo) Size() int64 {
 
 // Size indicates an expected call of Size
 func (mr *MockfileSizeInfoMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockfileSizeInfo)(nil).Size))
 }
 
@@ -332,6 +362,7 @@ func (m *MockinstanceMetadata) EXPECT() *MockinstanceMetadataMockRecorder {
 
 // Region mocks base method
 func (m *MockinstanceMetadata) Region() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Region")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -340,5 +371,6 @@ func (m *MockinstanceMetadata) Region() (string, error) {
 
 // Region indicates an expected call of Region
 func (mr *MockinstanceMetadataMockRecorder) Region() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockinstanceMetadata)(nil).Region))
 }

--- a/ecs-init/docker/backoff_mocks.go
+++ b/ecs-init/docker/backoff_mocks.go
@@ -49,6 +49,7 @@ func (m *MockBackoff) EXPECT() *MockBackoffMockRecorder {
 
 // Duration mocks base method
 func (m *MockBackoff) Duration() time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Duration")
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -56,11 +57,13 @@ func (m *MockBackoff) Duration() time.Duration {
 
 // Duration indicates an expected call of Duration
 func (mr *MockBackoffMockRecorder) Duration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Duration", reflect.TypeOf((*MockBackoff)(nil).Duration))
 }
 
 // ShouldRetry mocks base method
 func (m *MockBackoff) ShouldRetry() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldRetry")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -68,5 +71,6 @@ func (m *MockBackoff) ShouldRetry() bool {
 
 // ShouldRetry indicates an expected call of ShouldRetry
 func (mr *MockBackoffMockRecorder) ShouldRetry() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRetry", reflect.TypeOf((*MockBackoff)(nil).ShouldRetry))
 }

--- a/ecs-init/docker/dependencies.go
+++ b/ecs-init/docker/dependencies.go
@@ -32,6 +32,7 @@ import (
 type dockerclient interface {
 	ListImages(opts godocker.ListImagesOptions) ([]godocker.APIImages, error)
 	LoadImage(opts godocker.LoadImageOptions) error
+	Logs(opts godocker.LogsOptions) error
 	ListContainers(opts godocker.ListContainersOptions) ([]godocker.APIContainers, error)
 	RemoveContainer(opts godocker.RemoveContainerOptions) error
 	CreateContainer(opts godocker.CreateContainerOptions) (*godocker.Container, error)
@@ -89,6 +90,10 @@ func (d *_dockerclient) ListImages(opts godocker.ListImagesOptions) ([]godocker.
 
 func (d *_dockerclient) LoadImage(opts godocker.LoadImageOptions) error {
 	return d.docker.LoadImage(opts)
+}
+
+func (d *_dockerclient) Logs(opts godocker.LogsOptions) error {
+	return d.docker.Logs(opts)
 }
 
 func (d *_dockerclient) ListContainers(opts godocker.ListContainersOptions) ([]godocker.APIContainers, error) {

--- a/ecs-init/docker/dependencies_mocks.go
+++ b/ecs-init/docker/dependencies_mocks.go
@@ -49,6 +49,7 @@ func (m *Mockdockerclient) EXPECT() *MockdockerclientMockRecorder {
 
 // ListImages mocks base method
 func (m *Mockdockerclient) ListImages(opts go_dockerclient.ListImagesOptions) ([]go_dockerclient.APIImages, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImages", opts)
 	ret0, _ := ret[0].([]go_dockerclient.APIImages)
 	ret1, _ := ret[1].(error)
@@ -57,11 +58,13 @@ func (m *Mockdockerclient) ListImages(opts go_dockerclient.ListImagesOptions) ([
 
 // ListImages indicates an expected call of ListImages
 func (mr *MockdockerclientMockRecorder) ListImages(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*Mockdockerclient)(nil).ListImages), opts)
 }
 
 // LoadImage mocks base method
 func (m *Mockdockerclient) LoadImage(opts go_dockerclient.LoadImageOptions) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", opts)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -69,11 +72,27 @@ func (m *Mockdockerclient) LoadImage(opts go_dockerclient.LoadImageOptions) erro
 
 // LoadImage indicates an expected call of LoadImage
 func (mr *MockdockerclientMockRecorder) LoadImage(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*Mockdockerclient)(nil).LoadImage), opts)
+}
+
+// Logs mocks base method
+func (m *Mockdockerclient) Logs(opts go_dockerclient.LogsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logs", opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Logs indicates an expected call of Logs
+func (mr *MockdockerclientMockRecorder) Logs(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*Mockdockerclient)(nil).Logs), opts)
 }
 
 // ListContainers mocks base method
 func (m *Mockdockerclient) ListContainers(opts go_dockerclient.ListContainersOptions) ([]go_dockerclient.APIContainers, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainers", opts)
 	ret0, _ := ret[0].([]go_dockerclient.APIContainers)
 	ret1, _ := ret[1].(error)
@@ -82,11 +101,13 @@ func (m *Mockdockerclient) ListContainers(opts go_dockerclient.ListContainersOpt
 
 // ListContainers indicates an expected call of ListContainers
 func (mr *MockdockerclientMockRecorder) ListContainers(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*Mockdockerclient)(nil).ListContainers), opts)
 }
 
 // RemoveContainer mocks base method
 func (m *Mockdockerclient) RemoveContainer(opts go_dockerclient.RemoveContainerOptions) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainer", opts)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -94,11 +115,13 @@ func (m *Mockdockerclient) RemoveContainer(opts go_dockerclient.RemoveContainerO
 
 // RemoveContainer indicates an expected call of RemoveContainer
 func (mr *MockdockerclientMockRecorder) RemoveContainer(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*Mockdockerclient)(nil).RemoveContainer), opts)
 }
 
 // CreateContainer mocks base method
 func (m *Mockdockerclient) CreateContainer(opts go_dockerclient.CreateContainerOptions) (*go_dockerclient.Container, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", opts)
 	ret0, _ := ret[0].(*go_dockerclient.Container)
 	ret1, _ := ret[1].(error)
@@ -107,11 +130,13 @@ func (m *Mockdockerclient) CreateContainer(opts go_dockerclient.CreateContainerO
 
 // CreateContainer indicates an expected call of CreateContainer
 func (mr *MockdockerclientMockRecorder) CreateContainer(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*Mockdockerclient)(nil).CreateContainer), opts)
 }
 
 // StartContainer mocks base method
 func (m *Mockdockerclient) StartContainer(id string, hostConfig *go_dockerclient.HostConfig) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartContainer", id, hostConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -119,11 +144,13 @@ func (m *Mockdockerclient) StartContainer(id string, hostConfig *go_dockerclient
 
 // StartContainer indicates an expected call of StartContainer
 func (mr *MockdockerclientMockRecorder) StartContainer(id, hostConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContainer", reflect.TypeOf((*Mockdockerclient)(nil).StartContainer), id, hostConfig)
 }
 
 // WaitContainer mocks base method
 func (m *Mockdockerclient) WaitContainer(id string) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitContainer", id)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -132,11 +159,13 @@ func (m *Mockdockerclient) WaitContainer(id string) (int, error) {
 
 // WaitContainer indicates an expected call of WaitContainer
 func (mr *MockdockerclientMockRecorder) WaitContainer(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitContainer", reflect.TypeOf((*Mockdockerclient)(nil).WaitContainer), id)
 }
 
 // StopContainer mocks base method
 func (m *Mockdockerclient) StopContainer(id string, timeout uint) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopContainer", id, timeout)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -144,11 +173,13 @@ func (m *Mockdockerclient) StopContainer(id string, timeout uint) error {
 
 // StopContainer indicates an expected call of StopContainer
 func (mr *MockdockerclientMockRecorder) StopContainer(id, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*Mockdockerclient)(nil).StopContainer), id, timeout)
 }
 
 // Ping mocks base method
 func (m *Mockdockerclient) Ping() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -156,6 +187,7 @@ func (m *Mockdockerclient) Ping() error {
 
 // Ping indicates an expected call of Ping
 func (mr *MockdockerclientMockRecorder) Ping() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*Mockdockerclient)(nil).Ping))
 }
 
@@ -184,6 +216,7 @@ func (m *MockdockerClientFactory) EXPECT() *MockdockerClientFactoryMockRecorder 
 
 // NewVersionedClient mocks base method
 func (m *MockdockerClientFactory) NewVersionedClient(endpoint, apiVersionString string) (dockerclient, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewVersionedClient", endpoint, apiVersionString)
 	ret0, _ := ret[0].(dockerclient)
 	ret1, _ := ret[1].(error)
@@ -192,6 +225,7 @@ func (m *MockdockerClientFactory) NewVersionedClient(endpoint, apiVersionString 
 
 // NewVersionedClient indicates an expected call of NewVersionedClient
 func (mr *MockdockerClientFactoryMockRecorder) NewVersionedClient(endpoint, apiVersionString interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewVersionedClient", reflect.TypeOf((*MockdockerClientFactory)(nil).NewVersionedClient), endpoint, apiVersionString)
 }
 
@@ -220,6 +254,7 @@ func (m *MockfileSystem) EXPECT() *MockfileSystemMockRecorder {
 
 // ReadFile mocks base method
 func (m *MockfileSystem) ReadFile(filename string) ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", filename)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -228,5 +263,6 @@ func (m *MockfileSystem) ReadFile(filename string) ([]byte, error) {
 
 // ReadFile indicates an expected call of ReadFile
 func (mr *MockfileSystemMockRecorder) ReadFile(filename interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockfileSystem)(nil).ReadFile), filename)
 }

--- a/ecs-init/engine/dependencies.go
+++ b/ecs-init/engine/dependencies.go
@@ -31,6 +31,7 @@ type downloader interface {
 }
 
 type dockerClient interface {
+	GetContainerLogTail(logWindowSize string) string
 	IsAgentImageLoaded() (bool, error)
 	LoadImage(image io.Reader) error
 	RemoveExistingAgentContainer() error

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -50,6 +50,7 @@ func (m *Mockdownloader) EXPECT() *MockdownloaderMockRecorder {
 
 // IsAgentCached mocks base method
 func (m *Mockdownloader) IsAgentCached() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAgentCached")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -57,11 +58,13 @@ func (m *Mockdownloader) IsAgentCached() bool {
 
 // IsAgentCached indicates an expected call of IsAgentCached
 func (mr *MockdownloaderMockRecorder) IsAgentCached() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentCached", reflect.TypeOf((*Mockdownloader)(nil).IsAgentCached))
 }
 
 // DownloadAgent mocks base method
 func (m *Mockdownloader) DownloadAgent() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadAgent")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -69,11 +72,13 @@ func (m *Mockdownloader) DownloadAgent() error {
 
 // DownloadAgent indicates an expected call of DownloadAgent
 func (mr *MockdownloaderMockRecorder) DownloadAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadAgent", reflect.TypeOf((*Mockdownloader)(nil).DownloadAgent))
 }
 
 // LoadCachedAgent mocks base method
 func (m *Mockdownloader) LoadCachedAgent() (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadCachedAgent")
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
@@ -82,11 +87,13 @@ func (m *Mockdownloader) LoadCachedAgent() (io.ReadCloser, error) {
 
 // LoadCachedAgent indicates an expected call of LoadCachedAgent
 func (mr *MockdownloaderMockRecorder) LoadCachedAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCachedAgent", reflect.TypeOf((*Mockdownloader)(nil).LoadCachedAgent))
 }
 
 // LoadDesiredAgent mocks base method
 func (m *Mockdownloader) LoadDesiredAgent() (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadDesiredAgent")
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
@@ -95,11 +102,13 @@ func (m *Mockdownloader) LoadDesiredAgent() (io.ReadCloser, error) {
 
 // LoadDesiredAgent indicates an expected call of LoadDesiredAgent
 func (mr *MockdownloaderMockRecorder) LoadDesiredAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadDesiredAgent", reflect.TypeOf((*Mockdownloader)(nil).LoadDesiredAgent))
 }
 
 // RecordCachedAgent mocks base method
 func (m *Mockdownloader) RecordCachedAgent() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecordCachedAgent")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -107,11 +116,13 @@ func (m *Mockdownloader) RecordCachedAgent() error {
 
 // RecordCachedAgent indicates an expected call of RecordCachedAgent
 func (mr *MockdownloaderMockRecorder) RecordCachedAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordCachedAgent", reflect.TypeOf((*Mockdownloader)(nil).RecordCachedAgent))
 }
 
 // AgentCacheStatus mocks base method
 func (m *Mockdownloader) AgentCacheStatus() cache.CacheStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AgentCacheStatus")
 	ret0, _ := ret[0].(cache.CacheStatus)
 	return ret0
@@ -119,6 +130,7 @@ func (m *Mockdownloader) AgentCacheStatus() cache.CacheStatus {
 
 // AgentCacheStatus indicates an expected call of AgentCacheStatus
 func (mr *MockdownloaderMockRecorder) AgentCacheStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentCacheStatus", reflect.TypeOf((*Mockdownloader)(nil).AgentCacheStatus))
 }
 
@@ -145,8 +157,23 @@ func (m *MockdockerClient) EXPECT() *MockdockerClientMockRecorder {
 	return m.recorder
 }
 
+// GetContainerLogTail mocks base method
+func (m *MockdockerClient) GetContainerLogTail(logWindowSize string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerLogTail", logWindowSize)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetContainerLogTail indicates an expected call of GetContainerLogTail
+func (mr *MockdockerClientMockRecorder) GetContainerLogTail(logWindowSize interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerLogTail", reflect.TypeOf((*MockdockerClient)(nil).GetContainerLogTail), logWindowSize)
+}
+
 // IsAgentImageLoaded mocks base method
 func (m *MockdockerClient) IsAgentImageLoaded() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAgentImageLoaded")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -155,11 +182,13 @@ func (m *MockdockerClient) IsAgentImageLoaded() (bool, error) {
 
 // IsAgentImageLoaded indicates an expected call of IsAgentImageLoaded
 func (mr *MockdockerClientMockRecorder) IsAgentImageLoaded() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentImageLoaded", reflect.TypeOf((*MockdockerClient)(nil).IsAgentImageLoaded))
 }
 
 // LoadImage mocks base method
 func (m *MockdockerClient) LoadImage(image io.Reader) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadImage", image)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -167,11 +196,13 @@ func (m *MockdockerClient) LoadImage(image io.Reader) error {
 
 // LoadImage indicates an expected call of LoadImage
 func (mr *MockdockerClientMockRecorder) LoadImage(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadImage", reflect.TypeOf((*MockdockerClient)(nil).LoadImage), image)
 }
 
 // RemoveExistingAgentContainer mocks base method
 func (m *MockdockerClient) RemoveExistingAgentContainer() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveExistingAgentContainer")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -179,11 +210,13 @@ func (m *MockdockerClient) RemoveExistingAgentContainer() error {
 
 // RemoveExistingAgentContainer indicates an expected call of RemoveExistingAgentContainer
 func (mr *MockdockerClientMockRecorder) RemoveExistingAgentContainer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveExistingAgentContainer", reflect.TypeOf((*MockdockerClient)(nil).RemoveExistingAgentContainer))
 }
 
 // StartAgent mocks base method
 func (m *MockdockerClient) StartAgent() (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAgent")
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -192,11 +225,13 @@ func (m *MockdockerClient) StartAgent() (int, error) {
 
 // StartAgent indicates an expected call of StartAgent
 func (mr *MockdockerClientMockRecorder) StartAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAgent", reflect.TypeOf((*MockdockerClient)(nil).StartAgent))
 }
 
 // StopAgent mocks base method
 func (m *MockdockerClient) StopAgent() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopAgent")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -204,11 +239,13 @@ func (m *MockdockerClient) StopAgent() error {
 
 // StopAgent indicates an expected call of StopAgent
 func (mr *MockdockerClientMockRecorder) StopAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAgent", reflect.TypeOf((*MockdockerClient)(nil).StopAgent))
 }
 
 // LoadEnvVars mocks base method
 func (m *MockdockerClient) LoadEnvVars() map[string]string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadEnvVars")
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
@@ -216,6 +253,7 @@ func (m *MockdockerClient) LoadEnvVars() map[string]string {
 
 // LoadEnvVars indicates an expected call of LoadEnvVars
 func (mr *MockdockerClientMockRecorder) LoadEnvVars() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVars))
 }
 
@@ -244,6 +282,7 @@ func (m *MockloopbackRouting) EXPECT() *MockloopbackRoutingMockRecorder {
 
 // Enable mocks base method
 func (m *MockloopbackRouting) Enable() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enable")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -251,11 +290,13 @@ func (m *MockloopbackRouting) Enable() error {
 
 // Enable indicates an expected call of Enable
 func (mr *MockloopbackRoutingMockRecorder) Enable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enable", reflect.TypeOf((*MockloopbackRouting)(nil).Enable))
 }
 
 // RestoreDefault mocks base method
 func (m *MockloopbackRouting) RestoreDefault() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreDefault")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -263,6 +304,7 @@ func (m *MockloopbackRouting) RestoreDefault() error {
 
 // RestoreDefault indicates an expected call of RestoreDefault
 func (mr *MockloopbackRoutingMockRecorder) RestoreDefault() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreDefault", reflect.TypeOf((*MockloopbackRouting)(nil).RestoreDefault))
 }
 
@@ -291,6 +333,7 @@ func (m *MockcredentialsProxyRoute) EXPECT() *MockcredentialsProxyRouteMockRecor
 
 // Create mocks base method
 func (m *MockcredentialsProxyRoute) Create() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -298,11 +341,13 @@ func (m *MockcredentialsProxyRoute) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockcredentialsProxyRouteMockRecorder) Create() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockcredentialsProxyRoute)(nil).Create))
 }
 
 // Remove mocks base method
 func (m *MockcredentialsProxyRoute) Remove() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -310,5 +355,6 @@ func (m *MockcredentialsProxyRoute) Remove() error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockcredentialsProxyRouteMockRecorder) Remove() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockcredentialsProxyRoute)(nil).Remove))
 }

--- a/ecs-init/engine/engine_test.go
+++ b/ecs-init/engine/engine_test.go
@@ -257,6 +257,27 @@ func TestStartSupervisedExitsWhenTerminalFailure(t *testing.T) {
 	}
 }
 
+func TestLogContainerFailureAgentExitCodeFailure(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockDocker := NewMockdockerClient(mockCtrl)
+
+	mockDocker.EXPECT().RemoveExistingAgentContainer()
+	mockDocker.EXPECT().StartAgent().Return(2, nil)
+	mockDocker.EXPECT().GetContainerLogTail(gomock.Any())
+	mockDocker.EXPECT().RemoveExistingAgentContainer()
+	mockDocker.EXPECT().StartAgent().Return(0, errors.New("test error"))
+
+	engine := &Engine{
+		docker: mockDocker,
+	}
+	err := engine.StartSupervised()
+	if err == nil {
+		t.Error("Expected error to be returned but was nil")
+	}
+}
+
 func TestStartSupervisedExitsWhenTerminalSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/ecs-init/exec/iptables/cmd_mocks.go
+++ b/ecs-init/exec/iptables/cmd_mocks.go
@@ -48,6 +48,7 @@ func (m *MockCmd) EXPECT() *MockCmdMockRecorder {
 
 // CombinedOutput mocks base method
 func (m *MockCmd) CombinedOutput() ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CombinedOutput")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -56,11 +57,13 @@ func (m *MockCmd) CombinedOutput() ([]byte, error) {
 
 // CombinedOutput indicates an expected call of CombinedOutput
 func (mr *MockCmdMockRecorder) CombinedOutput() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCmd)(nil).CombinedOutput))
 }
 
 // Output mocks base method
 func (m *MockCmd) Output() ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Output")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -69,5 +72,6 @@ func (m *MockCmd) Output() ([]byte, error) {
 
 // Output indicates an expected call of Output
 func (mr *MockCmdMockRecorder) Output() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Output", reflect.TypeOf((*MockCmd)(nil).Output))
 }

--- a/ecs-init/exec/iptables/exec_mocks.go
+++ b/ecs-init/exec/iptables/exec_mocks.go
@@ -49,6 +49,7 @@ func (m *MockExec) EXPECT() *MockExecMockRecorder {
 
 // LookPath mocks base method
 func (m *MockExec) LookPath(file string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LookPath", file)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -57,11 +58,13 @@ func (m *MockExec) LookPath(file string) (string, error) {
 
 // LookPath indicates an expected call of LookPath
 func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
 }
 
 // Command mocks base method
 func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{name}
 	for _, a := range arg {
 		varargs = append(varargs, a)
@@ -73,6 +76,7 @@ func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 
 // Command indicates an expected call of Command
 func (mr *MockExecMockRecorder) Command(name interface{}, arg ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name}, arg...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockExec)(nil).Command), varargs...)
 }

--- a/ecs-init/exec/sysctl/cmd_mocks.go
+++ b/ecs-init/exec/sysctl/cmd_mocks.go
@@ -48,6 +48,7 @@ func (m *MockCmd) EXPECT() *MockCmdMockRecorder {
 
 // CombinedOutput mocks base method
 func (m *MockCmd) CombinedOutput() ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CombinedOutput")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -56,11 +57,13 @@ func (m *MockCmd) CombinedOutput() ([]byte, error) {
 
 // CombinedOutput indicates an expected call of CombinedOutput
 func (mr *MockCmdMockRecorder) CombinedOutput() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CombinedOutput", reflect.TypeOf((*MockCmd)(nil).CombinedOutput))
 }
 
 // Output mocks base method
 func (m *MockCmd) Output() ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Output")
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -69,5 +72,6 @@ func (m *MockCmd) Output() ([]byte, error) {
 
 // Output indicates an expected call of Output
 func (mr *MockCmdMockRecorder) Output() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Output", reflect.TypeOf((*MockCmd)(nil).Output))
 }

--- a/ecs-init/exec/sysctl/exec_mocks.go
+++ b/ecs-init/exec/sysctl/exec_mocks.go
@@ -49,6 +49,7 @@ func (m *MockExec) EXPECT() *MockExecMockRecorder {
 
 // LookPath mocks base method
 func (m *MockExec) LookPath(file string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LookPath", file)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -57,11 +58,13 @@ func (m *MockExec) LookPath(file string) (string, error) {
 
 // LookPath indicates an expected call of LookPath
 func (mr *MockExecMockRecorder) LookPath(file interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExec)(nil).LookPath), file)
 }
 
 // Command mocks base method
 func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{name}
 	for _, a := range arg {
 		varargs = append(varargs, a)
@@ -73,6 +76,7 @@ func (m *MockExec) Command(name string, arg ...string) cmd.Cmd {
 
 // Command indicates an expected call of Command
 func (mr *MockExecMockRecorder) Command(name interface{}, arg ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name}, arg...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockExec)(nil).Command), varargs...)
 }

--- a/ecs-init/gpu/nvidia_gpu_manager_mocks.go
+++ b/ecs-init/gpu/nvidia_gpu_manager_mocks.go
@@ -48,6 +48,7 @@ func (m *MockGPUManager) EXPECT() *MockGPUManagerMockRecorder {
 
 // Setup mocks base method
 func (m *MockGPUManager) Setup() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Setup")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -55,11 +56,13 @@ func (m *MockGPUManager) Setup() error {
 
 // Setup indicates an expected call of Setup
 func (mr *MockGPUManagerMockRecorder) Setup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockGPUManager)(nil).Setup))
 }
 
 // Initialize mocks base method
 func (m *MockGPUManager) Initialize() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -67,11 +70,13 @@ func (m *MockGPUManager) Initialize() error {
 
 // Initialize indicates an expected call of Initialize
 func (mr *MockGPUManagerMockRecorder) Initialize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockGPUManager)(nil).Initialize))
 }
 
 // Shutdown mocks base method
 func (m *MockGPUManager) Shutdown() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Shutdown")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -79,11 +84,13 @@ func (m *MockGPUManager) Shutdown() error {
 
 // Shutdown indicates an expected call of Shutdown
 func (mr *MockGPUManagerMockRecorder) Shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockGPUManager)(nil).Shutdown))
 }
 
 // GetGPUDeviceIDs mocks base method
 func (m *MockGPUManager) GetGPUDeviceIDs() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGPUDeviceIDs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -92,11 +99,13 @@ func (m *MockGPUManager) GetGPUDeviceIDs() ([]string, error) {
 
 // GetGPUDeviceIDs indicates an expected call of GetGPUDeviceIDs
 func (mr *MockGPUManagerMockRecorder) GetGPUDeviceIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUDeviceIDs", reflect.TypeOf((*MockGPUManager)(nil).GetGPUDeviceIDs))
 }
 
 // GetDriverVersion mocks base method
 func (m *MockGPUManager) GetDriverVersion() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDriverVersion")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -105,11 +114,13 @@ func (m *MockGPUManager) GetDriverVersion() (string, error) {
 
 // GetDriverVersion indicates an expected call of GetDriverVersion
 func (mr *MockGPUManagerMockRecorder) GetDriverVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDriverVersion", reflect.TypeOf((*MockGPUManager)(nil).GetDriverVersion))
 }
 
 // DetectGPUDevices mocks base method
 func (m *MockGPUManager) DetectGPUDevices() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetectGPUDevices")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -117,11 +128,13 @@ func (m *MockGPUManager) DetectGPUDevices() error {
 
 // DetectGPUDevices indicates an expected call of DetectGPUDevices
 func (mr *MockGPUManagerMockRecorder) DetectGPUDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectGPUDevices", reflect.TypeOf((*MockGPUManager)(nil).DetectGPUDevices))
 }
 
 // SaveGPUState mocks base method
 func (m *MockGPUManager) SaveGPUState() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveGPUState")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -129,5 +142,6 @@ func (m *MockGPUManager) SaveGPUState() error {
 
 // SaveGPUState indicates an expected call of SaveGPUState
 func (mr *MockGPUManagerMockRecorder) SaveGPUState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveGPUState", reflect.TypeOf((*MockGPUManager)(nil).SaveGPUState))
 }

--- a/ecs-init/vendor/github.com/golang/mock/gomock/call.go
+++ b/ecs-init/vendor/github.com/golang/mock/gomock/call.go
@@ -23,7 +23,7 @@ import (
 
 // Call represents an expected call to a mock.
 type Call struct {
-	t TestReporter // for triggering test failures on invalid call setup
+	t TestHelper // for triggering test failures on invalid call setup
 
 	receiver   interface{}  // the receiver of the method call
 	method     string       // the name of the method
@@ -46,10 +46,8 @@ type Call struct {
 
 // newCall creates a *Call. It requires the method type in order to support
 // unexported methods.
-func newCall(t TestReporter, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
-	if h, ok := t.(testHelper); ok {
-		h.Helper()
-	}
+func newCall(t TestHelper, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+	t.Helper()
 
 	// TODO: check arity, types.
 	margs := make([]Matcher, len(args))
@@ -159,9 +157,7 @@ func (c *Call) Do(f interface{}) *Call {
 
 // Return declares the values to be returned by the mocked function call.
 func (c *Call) Return(rets ...interface{}) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	mt := c.methodType
 	if len(rets) != mt.NumOut() {
@@ -209,9 +205,7 @@ func (c *Call) Times(n int) *Call {
 // indirected through a pointer. Or, in the case of a slice, SetArg
 // will copy value's elements into the nth argument.
 func (c *Call) SetArg(n int, value interface{}) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	mt := c.methodType
 	// TODO: This will break on variadic methods.
@@ -264,9 +258,7 @@ func (c *Call) isPreReq(other *Call) bool {
 
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	if c == preReq {
 		c.t.Fatalf("A call isn't allowed to be its own prerequisite")
@@ -339,14 +331,14 @@ func (c *Call) matches(args []interface{}) error {
 			// The last arg has a possibility of a variadic argument, so let it branch
 
 			// sample: Foo(a int, b int, c ...int)
-			if len(c.args) == len(args) {
+			if i < len(c.args) && i < len(args) {
 				if m.Matches(args[i]) {
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, gomock.Any())
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, someSliceMatcher)
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC)
 					// Got Foo(a, b) want Foo(matcherA, matcherB)
 					// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
-					break
+					continue
 				}
 			}
 

--- a/ecs-init/vendor/github.com/golang/mock/gomock/controller.go
+++ b/ecs-init/vendor/github.com/golang/mock/gomock/controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// GoMock - a mock framework for Go.
+// Package gomock is a mock framework for Go.
 //
 // Standard usage:
 //   (1) Define an interface that you wish to mock.
@@ -56,59 +56,111 @@
 package gomock
 
 import (
+	"context"
 	"fmt"
-	"golang.org/x/net/context"
 	"reflect"
 	"runtime"
 	"sync"
 )
 
-// A TestReporter is something that can be used to report test failures.
-// It is satisfied by the standard library's *testing.T.
+// A TestReporter is something that can be used to report test failures.  It
+// is satisfied by the standard library's *testing.T.
 type TestReporter interface {
 	Errorf(format string, args ...interface{})
 	Fatalf(format string, args ...interface{})
 }
 
-// A Controller represents the top-level control of a mock ecosystem.
-// It defines the scope and lifetime of mock objects, as well as their expectations.
-// It is safe to call Controller's methods from multiple goroutines.
+// TestHelper is a TestReporter that has the Helper method.  It is satisfied
+// by the standard library's *testing.T.
+type TestHelper interface {
+	TestReporter
+	Helper()
+}
+
+// A Controller represents the top-level control of a mock ecosystem.  It
+// defines the scope and lifetime of mock objects, as well as their
+// expectations.  It is safe to call Controller's methods from multiple
+// goroutines. Each test should create a new Controller and invoke Finish via
+// defer.
+//
+//   func TestFoo(t *testing.T) {
+//     ctrl := gomock.NewController(st)
+//     defer ctrl.Finish()
+//     // ..
+//   }
+//
+//   func TestBar(t *testing.T) {
+//     t.Run("Sub-Test-1", st) {
+//       ctrl := gomock.NewController(st)
+//       defer ctrl.Finish()
+//       // ..
+//     })
+//     t.Run("Sub-Test-2", st) {
+//       ctrl := gomock.NewController(st)
+//       defer ctrl.Finish()
+//       // ..
+//     })
+//   })
 type Controller struct {
+	// T should only be called within a generated mock. It is not intended to
+	// be used in user code and may be changed in future versions. T is the
+	// TestReporter passed in when creating the Controller via NewController.
+	// If the TestReporter does not implement a TestHelper it will be wrapped
+	// with a nopTestHelper.
+	T             TestHelper
 	mu            sync.Mutex
-	t             TestReporter
 	expectedCalls *callSet
 	finished      bool
 }
 
+// NewController returns a new Controller. It is the preferred way to create a
+// Controller.
 func NewController(t TestReporter) *Controller {
+	h, ok := t.(TestHelper)
+	if !ok {
+		h = nopTestHelper{t}
+	}
+
 	return &Controller{
-		t:             t,
+		T:             h,
 		expectedCalls: newCallSet(),
 	}
 }
 
 type cancelReporter struct {
-	t      TestReporter
+	TestHelper
 	cancel func()
 }
 
-func (r *cancelReporter) Errorf(format string, args ...interface{}) { r.t.Errorf(format, args...) }
+func (r *cancelReporter) Errorf(format string, args ...interface{}) {
+	r.TestHelper.Errorf(format, args...)
+}
 func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
 	defer r.cancel()
-	r.t.Fatalf(format, args...)
+	r.TestHelper.Fatalf(format, args...)
 }
 
 // WithContext returns a new Controller and a Context, which is cancelled on any
 // fatal failure.
 func WithContext(ctx context.Context, t TestReporter) (*Controller, context.Context) {
+	h, ok := t.(TestHelper)
+	if !ok {
+		h = nopTestHelper{t}
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
-	return NewController(&cancelReporter{t, cancel}), ctx
+	return NewController(&cancelReporter{h, cancel}), ctx
 }
 
+type nopTestHelper struct {
+	TestReporter
+}
+
+func (h nopTestHelper) Helper() {}
+
+// RecordCall is called by a mock. It should not be called by user code.
 func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	recv := reflect.ValueOf(receiver)
 	for i := 0; i < recv.Type().NumMethod(); i++ {
@@ -116,16 +168,15 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 			return ctrl.RecordCallWithMethodType(receiver, method, recv.Method(i).Type(), args...)
 		}
 	}
-	ctrl.t.Fatalf("gomock: failed finding method %s on %T", method, receiver)
+	ctrl.T.Fatalf("gomock: failed finding method %s on %T", method, receiver)
 	panic("unreachable")
 }
 
+// RecordCallWithMethodType is called by a mock. It should not be called by user code.
 func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
-	call := newCall(ctrl.t, receiver, method, methodType, args...)
+	call := newCall(ctrl.T, receiver, method, methodType, args...)
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
@@ -134,20 +185,20 @@ func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method st
 	return call
 }
 
+// Call is called by a mock. It should not be called by user code.
 func (ctrl *Controller) Call(receiver interface{}, method string, args ...interface{}) []interface{} {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	// Nest this code so we can use defer to make sure the lock is released.
 	actions := func() []func([]interface{}) []interface{} {
+		ctrl.T.Helper()
 		ctrl.mu.Lock()
 		defer ctrl.mu.Unlock()
 
 		expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
 		if err != nil {
 			origin := callerInfo(2)
-			ctrl.t.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
+			ctrl.T.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
 		}
 
 		// Two things happen here:
@@ -175,16 +226,17 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
+// Finish checks to see if all the methods that were expected to be called
+// were called. It should be invoked for each Controller. It is not idempotent
+// and therefore can only be invoked once.
 func (ctrl *Controller) Finish() {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
 	if ctrl.finished {
-		ctrl.t.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+		ctrl.T.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
 	}
 	ctrl.finished = true
 
@@ -197,10 +249,10 @@ func (ctrl *Controller) Finish() {
 	// Check that all remaining expected calls are satisfied.
 	failures := ctrl.expectedCalls.Failures()
 	for _, call := range failures {
-		ctrl.t.Errorf("missing call(s) to %v", call)
+		ctrl.T.Errorf("missing call(s) to %v", call)
 	}
 	if len(failures) != 0 {
-		ctrl.t.Fatalf("aborting test due to missing call(s)")
+		ctrl.T.Fatalf("aborting test due to missing call(s)")
 	}
 }
 
@@ -209,9 +261,4 @@ func callerInfo(skip int) string {
 		return fmt.Sprintf("%s:%d", file, line)
 	}
 	return "unknown file"
-}
-
-type testHelper interface {
-	TestReporter
-	Helper()
 }

--- a/ecs-init/vendor/github.com/golang/mock/gomock/matchers.go
+++ b/ecs-init/vendor/github.com/golang/mock/gomock/matchers.go
@@ -1,5 +1,3 @@
-//go:generate mockgen -destination mock_matcher/mock_matcher.go github.com/golang/mock/gomock Matcher
-
 // Copyright 2010 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,13 +85,57 @@ func (n notMatcher) String() string {
 	return "not(" + n.m.String() + ")"
 }
 
+type assignableToTypeOfMatcher struct {
+	targetType reflect.Type
+}
+
+func (m assignableToTypeOfMatcher) Matches(x interface{}) bool {
+	return reflect.TypeOf(x).AssignableTo(m.targetType)
+}
+
+func (m assignableToTypeOfMatcher) String() string {
+	return "is assignable to " + m.targetType.Name()
+}
+
 // Constructors
-func Any() Matcher             { return anyMatcher{} }
+// Any returns a matcher that always matches.
+func Any() Matcher { return anyMatcher{} }
+
+// Eq returns a matcher that matches on equality.
+//
+// Example usage:
+//   Eq(5).Matches(5) // returns true
+//   Eq(5).Matches(4) // returns false
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
-func Nil() Matcher             { return nilMatcher{} }
+
+// Nil returns a matcher that matches if the received value is nil.
+//
+// Example usage:
+//   var x *bytes.Buffer
+//   Nil().Matches(x) // returns true
+//   x = &bytes.Buffer{}
+//   Nil().Matches(x) // returns false
+func Nil() Matcher { return nilMatcher{} }
+
+// Not reverses the results of its given child matcher.
+//
+// Example usage:
+//   Not(Eq(5)).Matches(4) // returns true
+//   Not(Eq(5)).Matches(5) // returns false
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}
 	}
 	return notMatcher{Eq(x)}
+}
+
+// AssignableToTypeOf is a Matcher that matches if the parameter to the mock
+// function is assignable to the type of the parameter to this function.
+//
+// Example usage:
+//   var s fmt.Stringer = &bytes.Buffer{}
+//   AssignableToTypeOf(s).Matches(time.Second) // returns true
+//   AssignableToTypeOf(s).Matches(99) // returns false
+func AssignableToTypeOf(x interface{}) Matcher {
+	return assignableToTypeOfMatcher{reflect.TypeOf(x)}
 }


### PR DESCRIPTION
Author:    fierlion <fierlion@amazon.com>
Date:      Fri Dec 6 00:21:02 2019 +0000
Committer: fierlion <fierlion@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
When the agent container fails, ecs-init removes the container as it starts up another.  We lose the failed container's logs.  This captures a set window of agent container logs and adds them to the ecs-init log for a failed container (exit code 2).

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
In order to avoid possibly searching through a large log, this uses the --tail flag of the docker Log and a pre-configured window (here set to 200 lines).  This assures us consistent performance.  I added a panic() to the agent container binary to force the agent container failed exit.  This returned a '2' exit code.  
We can tweak the window and potentially the exit code(s) we capture logs for over time as necessary.

### Testing
<!-- How was this tested? -->
I tested with a custom build agent with a panic in the StopContainer.  This allowed me to start an ecs task using ecs-cli, confirm that it was running using `docker ps` and then use the cli to stop the task which triggered the panic() in the agent and caused the agent container to fail.  I was able to capture logs from this failed container in `/var/log/ecs/ecs-init.log`.

New tests cover the changes: <!-- yes|no -->
Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Capture a fixed tail of container logs when removing a container

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->

