### PR TITLE
store state information of the plugin to disk

### DIFF
--- a/ecs-init/volumes/amazon-ecs-volume-plugin/plugin.go
+++ b/ecs-init/volumes/amazon-ecs-volume-plugin/plugin.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"os"
 	"os/user"
 	"strconv"
 
@@ -23,6 +24,9 @@ import (
 
 func main() {
 	plugin := volumes.NewAmazonECSVolumePlugin()
+	if err := plugin.LoadState(); err != nil {
+		os.Exit(1)
+	}
 	handler := volume.NewHandler(plugin)
 	rootUser, _ := user.Lookup("root")
 	gid, _ := strconv.Atoi(rootUser.Gid)

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -1,0 +1,141 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	// PluginStatePath is the directory path to the plugin state information
+	// TODO: get this value from an env var
+	PluginStatePath = "/var/lib/ecs/data/"
+	// PluginStateFile contains the state information of the plugin
+	PluginStateFile = "ecs_volume_plugin.json"
+	// PluginStateFileAbsPath is the absolute path of the plugin state file
+	PluginStateFileAbsPath = "/var/lib/ecs/data/ecs_volume_plugin.json"
+)
+
+// StateManager manages the state of the volumes information
+type StateManager struct {
+	VolState *VolumeState
+	lock     sync.Mutex
+}
+
+// VolumeState contains the list of managed volumes
+type VolumeState struct {
+	Volumes map[string]*VolumeInfo `json:"volumes,omitempty"`
+}
+
+// VolumeInfo contains the information of managed volumes
+type VolumeInfo struct {
+	Type    string            `json:"type,omitempty"`
+	Path    string            `json:"path,omitempty"`
+	Options map[string]string `json:"options,omitempty"`
+}
+
+// NewStateManager initializes the state manager of volume plugin
+func NewStateManager() *StateManager {
+	return &StateManager{
+		VolState: &VolumeState{
+			Volumes: make(map[string]*VolumeInfo),
+		},
+	}
+}
+
+func (s *StateManager) recordVolume(volName string, vol *Volume) error {
+	s.VolState.Volumes[volName] = &VolumeInfo{
+		Type:    vol.Type,
+		Path:    vol.Path,
+		Options: vol.Options,
+	}
+	return s.save()
+}
+
+func (s *StateManager) removeVolume(volName string) error {
+	delete(s.VolState.Volumes, volName)
+	return s.save()
+}
+
+// saves volume state to the file at path
+func (s *StateManager) save() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	b, err := json.MarshalIndent(s.VolState, "", "\t")
+	if err != nil {
+		return fmt.Errorf("could not marshal data to save state: %v", err)
+	}
+
+	// Make our temp-file on the same volume as our data-file to ensure we can
+	// actually move it atomically; cross-device renaming will error out
+	tmpfile, err := ioutil.TempFile(PluginStatePath, "tmp_ecs_volume_plugin")
+	if err != nil {
+		return fmt.Errorf("could not create temp file to save state, err: %v", err)
+	}
+	_, err = tmpfile.Write(b)
+	if err != nil {
+		return fmt.Errorf("could not write to temp file to save state, err: %v", err)
+	}
+
+	// flush temp state file to disk
+	err = tmpfile.Sync()
+	if err != nil {
+		return fmt.Errorf("error flusing state file, err: %v", err)
+	}
+
+	err = os.Rename(tmpfile.Name(), filepath.Join(PluginStatePath, PluginStateFile))
+	if err != nil {
+		return fmt.Errorf("could not move data to state file, err: %v", err)
+	}
+
+	stateDir, err := os.Open(PluginStatePath)
+	if err != nil {
+		return fmt.Errorf("error opening state path, err: %v", err)
+	}
+
+	// sync directory entry of the new state file to disk
+	err = stateDir.Sync()
+	if err != nil {
+		return fmt.Errorf("error syncing state file directory entry, err: %v", err)
+	}
+	return err
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}
+
+// loads the file at path into interface 'a'
+func (s *StateManager) load(a interface{}) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	f, err := os.Open(PluginStateFileAbsPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(a)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal state: %v", err)
+	}
+	return err
+}

--- a/ecs-init/volumes/state_manager_test.go
+++ b/ecs-init/volumes/state_manager_test.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaveStateSuccess(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		assert.Equal(t, string(`{
+	"volumes": {
+		"vol": {
+			"type": "efs",
+			"path": "/vol"
+		}
+	}
+}`), string(b))
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, s.save())
+}
+
+func TestSaveStateToDisk(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, s.save())
+}
+
+func TestSaveStateToDiskFail(t *testing.T) {
+	s := NewStateManager()
+	s.VolState.Volumes["vol"] = &VolumeInfo{
+		Type: "efs",
+		Path: "/vol",
+	}
+	saveStateToDisk = func(b []byte) error {
+		return errors.New("write to disk failure")
+	}
+	defer func() {
+		saveStateToDisk = saveState
+	}()
+	assert.Error(t, s.save())
+}
+
+func TestLoadStateSuccess(t *testing.T) {
+	s := NewStateManager()
+	oldState := &VolumeState{}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`{"volumes":{"efsVolume":{"type":"efs","options":{"device":"fs-123","o":"tls","type":"efs"}}}}`), nil
+	}
+	defer func() {
+		readStateFile = readFile
+	}()
+	assert.NoError(t, s.load(oldState))
+}
+
+func TestLoadInvalidState(t *testing.T) {
+	s := NewStateManager()
+	oldState := &VolumeState{}
+	readStateFile = func() ([]byte, error) {
+		return []byte(`"junk"`), nil
+	}
+	defer func() {
+		readStateFile = readFile
+	}()
+	assert.Error(t, s.load(oldState))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Amazon ECS Volume Plugin writes state information of the volumes
that it manages to `/var/lib/ecs/data/ecs_volume_plugin.json`. On
startup, it loads the volumes information from the disk and periodically
saves state on each volume's successful create and delete operations.
Tested manually.
state file after creating volume `efsVolume456` : 
```
$ sudo cat /var/lib/ecs/data/ecs_volume_plugin.json
{
	"volumes": {
		"efsVolume456": {
			"type": "efs",
			"path": "/var/lib/ecs/volumes/efsVolume456",
			"options": {
				"device": "fs-1cf5f8b7",
				"o": "tls",
				"type": "efs"
			}
		}
	}
}
```
stopped the plugin and restarted 
```
$ docker volume ls
amazon-ecs-volume-plugin   efsVolume456
```
volume removal:
```
$ docker volume rm efsVolume456

$ sudo cat /var/lib/ecs/data/ecs_volume_plugin.json
{}

```


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
