### PR TITLE
Volume Plugin logging

### DIFF
--- a/ecs-init/volumes/amazon-ecs-volume-plugin/plugin.go
+++ b/ecs-init/volumes/amazon-ecs-volume-plugin/plugin.go
@@ -19,16 +19,21 @@ import (
 	"strconv"
 
 	"github.com/aws/amazon-ecs-init/ecs-init/volumes"
+	"github.com/aws/amazon-ecs-init/ecs-init/volumes/logger"
+	"github.com/cihub/seelog"
 	"github.com/docker/go-plugins-helpers/volume"
 )
 
 func main() {
 	plugin := volumes.NewAmazonECSVolumePlugin()
+	logger.Setup()
+	defer seelog.Flush()
 	if err := plugin.LoadState(); err != nil {
 		os.Exit(1)
 	}
 	handler := volume.NewHandler(plugin)
 	rootUser, _ := user.Lookup("root")
 	gid, _ := strconv.Atoi(rootUser.Gid)
+	seelog.Info("Starting volume plugin..")
 	handler.ServeUnix("amazon-ecs-volume-plugin", gid)
 }

--- a/ecs-init/volumes/efs_mount_helper.go
+++ b/ecs-init/volumes/efs_mount_helper.go
@@ -45,7 +45,6 @@ func (m *MountHelper) Mount() error {
 		args = append(args, "-o", m.Options)
 	}
 	args = append(args, m.Device, m.Target)
-
 	if err := m.Validate(); err != nil {
 		return err
 	}

--- a/ecs-init/volumes/logger/log.go
+++ b/ecs-init/volumes/logger/log.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/cihub/seelog"
+)
+
+const (
+	logFileFormat = "/var/log/ecs/ecs-volume-plugin.log"
+	logLevel      = "info"
+	outputFmt     = "logfmt"
+	rollCount     = 24
+)
+
+type logConfig struct {
+	logfile      string
+	level        string
+	outputFormat string
+	maxRollCount int
+}
+
+// config contains config for seelog logger
+var config *logConfig
+
+// Setup sets the cusotm logging config
+func Setup() {
+	config = &logConfig{
+		logfile:      logFileFormat,
+		level:        logLevel,
+		outputFormat: outputFmt,
+		maxRollCount: rollCount,
+	}
+
+	if err := seelog.RegisterCustomFormatter("VolumePluginLogfmt", logfmtFormatter); err != nil {
+		seelog.Error(err)
+	}
+	reloadConfig()
+}
+
+func logfmtFormatter(params string) seelog.FormatterFunc {
+	return func(message string, level seelog.LogLevel, context seelog.LogContextInterface) interface{} {
+		return fmt.Sprintf(`level=%s time=%s msg=%q
+`, level.String(), context.CallTime().UTC().Format(time.RFC3339), message)
+	}
+}
+
+func reloadConfig() {
+	logger, err := seelog.LoggerFromConfigAsString(seelogConfig())
+	if err == nil {
+		seelog.ReplaceLogger(logger)
+	} else {
+		seelog.Error(err)
+	}
+}
+
+func seelogConfig() string {
+	c := `
+<seelog type="asyncloop" minlevel="` + config.level + `">
+	<outputs formatid="` + config.outputFormat + `">
+		<console />`
+	if config.logfile != "" {
+		c += `
+		<rollingfile filename="` + config.logfile + `" type="date"
+		 datepattern="2006-01-02-15" archivetype="none" maxrolls="` + strconv.Itoa(config.maxRollCount) + `" />`
+	}
+	c += `
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%VolumePluginLogfmt" />
+	</formats>
+</seelog>`
+	return c
+}

--- a/ecs-init/volumes/logger/log_test.go
+++ b/ecs-init/volumes/logger/log_test.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogfmtFormat(t *testing.T) {
+	logfmt := logfmtFormatter("")
+	out := logfmt("This is my log message", seelog.InfoLvl, &LogContextMock{})
+	s, ok := out.(string)
+	assert.True(t, ok)
+	assert.Equal(t, `level=info time=2018-10-01T01:02:03Z msg="This is my log message"
+`, s)
+}
+
+func TestSeelogConfig(t *testing.T) {
+	config = &logConfig{
+		logfile:      "foo.log",
+		level:        logLevel,
+		outputFormat: outputFmt,
+		maxRollCount: 24,
+	}
+	c := seelogConfig()
+	assert.Equal(t, `
+<seelog type="asyncloop" minlevel="info">
+	<outputs formatid="logfmt">
+		<console />
+		<rollingfile filename="foo.log" type="date"
+		 datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />
+	</outputs>
+	<formats>
+		<format id="logfmt" format="%VolumePluginLogfmt" />
+	</formats>
+</seelog>`, c)
+}
+
+type LogContextMock struct{}
+
+// Caller's function name.
+func (l *LogContextMock) Func() string {
+	return ""
+}
+
+// Caller's line number.
+func (l *LogContextMock) Line() int {
+	return 0
+}
+
+// Caller's file short path (in slashed form).
+func (l *LogContextMock) ShortPath() string {
+	return ""
+}
+
+// Caller's file full path (in slashed form).
+func (l *LogContextMock) FullPath() string {
+	return ""
+}
+
+// True if the context is correct and may be used.
+// If false, then an error in context evaluation occurred and
+// all its other data may be corrupted.
+func (l *LogContextMock) IsValid() bool {
+	return true
+}
+
+// Time when log function was called.
+func (l *LogContextMock) CallTime() time.Time {
+	return time.Date(2018, time.October, 1, 1, 2, 3, 0, time.UTC)
+}
+
+// Custom context that can be set by calling logger.SetContext
+func (l *LogContextMock) CustomContext() interface{} {
+	return map[string]string{}
+}
+
+// Caller's file name (without path).
+func (l *LogContextMock) FileName() string {
+	return "mytestmodule.go"
+}

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -80,7 +80,7 @@ func (s *StateManager) save() error {
 
 	b, err := json.MarshalIndent(s.VolState, "", "\t")
 	if err != nil {
-		return fmt.Errorf("could not marshal data to save state: %v", err)
+		return fmt.Errorf("marshal data failed: %v", err)
 	}
 	return saveStateToDisk(b)
 }
@@ -92,33 +92,33 @@ func saveState(b []byte) error {
 	// actually move it atomically; cross-device renaming will error out
 	tmpfile, err := ioutil.TempFile(PluginStatePath, "tmp_ecs_volume_plugin")
 	if err != nil {
-		return fmt.Errorf("could not create temp file to save state, err: %v", err)
+		return fmt.Errorf("failed to create temp file: %v", err)
 	}
 	_, err = tmpfile.Write(b)
 	if err != nil {
-		return fmt.Errorf("could not write to temp file to save state, err: %v", err)
+		return fmt.Errorf("failed to write state to temp file: %v", err)
 	}
 
 	// flush temp state file to disk
 	err = tmpfile.Sync()
 	if err != nil {
-		return fmt.Errorf("error flushing state file, err: %v", err)
+		return fmt.Errorf("error flushing state file: %v", err)
 	}
 
 	err = os.Rename(tmpfile.Name(), filepath.Join(PluginStatePath, PluginStateFile))
 	if err != nil {
-		return fmt.Errorf("could not move data to state file, err: %v", err)
+		return fmt.Errorf("could not move data to state file: %v", err)
 	}
 
 	stateDir, err := os.Open(PluginStatePath)
 	if err != nil {
-		return fmt.Errorf("error opening state path, err: %v", err)
+		return fmt.Errorf("error opening state path: %v", err)
 	}
 
 	// sync directory entry of the new state file to disk
 	err = stateDir.Sync()
 	if err != nil {
-		return fmt.Errorf("error syncing state file directory entry, err: %v", err)
+		return fmt.Errorf("error syncing state file directory entry: %v", err)
 	}
 	return nil
 }
@@ -141,7 +141,7 @@ func (s *StateManager) load(a interface{}) error {
 	}
 	err = json.Unmarshal(b, a)
 	if err != nil {
-		return fmt.Errorf("could not unmarshal state: %v", err)
+		return err
 	}
 	return err
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Implementation details
Using logfmt for seelog, and rollover based on date with roll count of 24 (mimicking agent's default logging behavior) 
Log file: `/var/log/ecs/ecs-volume-plugin.log`

Sample: 
```
level=info time=2020-01-13T20:16:20Z msg="Loading plugin state information"
level=info time=2020-01-13T20:16:20Z msg="starting volume plugin.."
level=info time=2020-01-13T20:16:27Z msg="Creating new volume efsvolume"
level=info time=2020-01-13T20:16:27Z msg="Creating mount target for new volume efsvolume"
level=info time=2020-01-13T20:16:27Z msg="Validating create options for volume efsvolume"
level=info time=2020-01-13T20:16:27Z msg="Mounting volume efsvolume at path /var/lib/ecs/volumes4/efsvolume with options tls"
level=info time=2020-01-13T20:16:27Z msg="Volume efsvolume created successfully"
level=info time=2020-01-13T20:16:27Z msg="Saving state of new volume efsvolume"
level=info time=2020-01-13T20:19:20Z msg="Loading plugin state information"
level=info time=2020-01-13T20:19:20Z msg="starting volume plugin.."
level=info time=2020-01-13T20:20:03Z msg="Removing volume efsvolume"
level=info time=2020-01-13T20:20:03Z msg="Saving state after removing volume efsvolume"
``` 

### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
