### PR TITLE
Update suse systemd Unit file

### DIFF
--- a/packaging/suse/amazon-ecs.service
+++ b/packaging/suse/amazon-ecs.service
@@ -10,7 +10,8 @@ Requires=network.target
 Type=simple
 ExecStartPre=/usr/sbin/amazon-ecs-init pre-start
 ExecStart=/usr/sbin/amazon-ecs-init start
-ExecStop=/usr/sbin/amazon-ecs-init pre-stop
+ExecStop=/usr/sbin/amazon-ecs-init stop
+ExecStopPost=/usr/sbin/amazon-ecs-init post-stop
 ExecReload=/usr/sbin/amazon-ecs-init reload-cache
 
 [Install]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This adds the appropriate stop, post-stop directives as requested here:
https://github.com/aws/amazon-ecs-init/issues/182

### Implementation details
<!-- How are the changes implemented?
Added 
If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
The `pre-stop` and `stop` actions point to the same `engine.PreStop` function
https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/ecs-init.go#L97-L104
I updated the ExecStop to point to `stop` so it mirrors what we have in amazon-linux-ami
https://github.com/aws/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs.service#L29-L30
I also added the ExecStopPost directive.  
See testing for more detail.
### Testing
<!-- How was this tested? -->
1. Started a new EC2 instance from the `SUSE Linux Enterprise Server 15 SP1 (HVM), SSD Volume Type - ami-0e6612c7b620ecf3a` AMI in us-west-2.  
2. Set up Docker, provisioned host with necessary RPMs and then pulled the latest ECS-agent image from DockerHub.  
3. Cloned amazon-ecs-init and made the updates included here in the SUSE Unit file
4. Built ecs-init on the host directly using the above ecs-agent container with `make rpm`.  
4.  Installed the rpm using `sudo rpm -i <rpm file>`
5. Manually copied the new unit file into /etc/systemd/system and the amazon-ecs-init binary into `/usr/sbin/` and ran `sudo systemctl enable /etc/systemd/system/amazon-ecs.service`
6. Started up ecs-agent container using `sudo systemctl start amazon-ecs`.  Waited for the agent container to become healthy.
7. Stopped the ecs-agent container with `sudo systemctl stop amazon-ecs`
8. Verified `/var/log/ecs/ecs-init.log` contained the expected INFO output from the new post-stop step:
```
2020-01-10T18:23:33Z [INFO] post-stop
2020-01-10T18:23:33Z [INFO] Cleaning up the credentials endpoint setup for Amazon Elastic Container Service Agent
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
