### PR TITLE
allow no type for volume; populate volume state after load

### DIFF
--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -14,7 +14,6 @@
 package volumes
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -27,7 +26,8 @@ const (
 	// VolumeMountPathPrefix is the host path where amazon ECS plugin's volumes are mounted
 	VolumeMountPathPrefix = "/var/lib/ecs/volumes/"
 	// FilePerm is the file permissions for the host volume mount directory
-	FilePerm = 0700
+	FilePerm          = 0700
+	defaultDriverType = "efs"
 )
 
 // AmazonECSVolumePlugin holds list of volume drivers and volumes information
@@ -106,11 +106,15 @@ func (a *AmazonECSVolumePlugin) LoadState() error {
 		}
 		a.volumes[volName] = volume
 		voldriver.Setup(volName, volume)
+		a.state.recordVolume(volName, volume)
 	}
 	return nil
 }
 
 func (a *AmazonECSVolumePlugin) getVolumeDriver(driverType string) (VolumeDriver, error) {
+	if driverType == "" {
+		return a.volumeDrivers[defaultDriverType], nil
+	}
 	if _, ok := a.volumeDrivers[driverType]; !ok {
 		return nil, fmt.Errorf("volume %s type not supported", driverType)
 	}
@@ -135,10 +139,6 @@ func (a *AmazonECSVolumePlugin) Create(r *volume.CreateRequest) error {
 		case "type":
 			driverType = v
 		}
-	}
-	if driverType == "" {
-		seelog.Errorf("Volume type required for volume %s creation", r.Name)
-		return errors.New("volume type not specified")
 	}
 	volDriver, err := a.getVolumeDriver(driverType)
 	if err != nil {
@@ -177,7 +177,6 @@ func (a *AmazonECSVolumePlugin) Create(r *volume.CreateRequest) error {
 
 	// record the volume information
 	a.volumes[r.Name] = vol
-
 	seelog.Infof("Saving state of new volume %s", r.Name)
 	// save the state of new volume
 	err = a.state.recordVolume(r.Name, vol)

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -154,18 +154,29 @@ func TestVolumeCreateFailure(t *testing.T) {
 	assert.Len(t, plugin.volumes, 0)
 }
 
-func TestCreateNoVolumeTypeFailure(t *testing.T) {
+func TestCreateNoVolumeType(t *testing.T) {
 	plugin := &AmazonECSVolumePlugin{
 		volumeDrivers: map[string]VolumeDriver{
 			"efs": NewTestVolumeDriver(),
 		},
 		volumes: make(map[string]*Volume),
+		state:   NewStateManager(),
 	}
 	req := &volume.CreateRequest{
 		Name: "vol",
 	}
-	assert.Error(t, plugin.Create(req), "expected create error when no volume type specified")
-	assert.Len(t, plugin.volumes, 0)
+	createMountPath = func(path string) error {
+		return nil
+	}
+	saveStateToDisk = func(b []byte) error {
+		return nil
+	}
+	defer func() {
+		createMountPath = createMountDir
+		saveStateToDisk = saveState
+	}()
+	assert.NoError(t, plugin.Create(req), "expected no create error when no volume type specified")
+	assert.Len(t, plugin.volumes, 1)
 }
 
 func TestCreateNoDriverFailure(t *testing.T) {
@@ -524,6 +535,12 @@ func TestPluginLoadState(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "efs", vol.Type)
 	assert.Equal(t, VolumeMountPathPrefix+"efsVolume", vol.Path)
+	vols := plugin.state.VolState.Volumes
+	assert.Len(t, vols, 1)
+	volInfo, ok := vols["efsVolume"]
+	assert.True(t, ok)
+	assert.Equal(t, "efs", volInfo.Type)
+	assert.Equal(t, VolumeMountPathPrefix+"efsVolume", volInfo.Path)
 }
 
 func TestPluginNoStateFile(t *testing.T) {

--- a/ecs-init/volumes/efs_mount_helper.go
+++ b/ecs-init/volumes/efs_mount_helper.go
@@ -61,9 +61,6 @@ func runMountCommand(args []string) error {
 // Validate validates fields as part of the mount command
 func (m *MountHelper) Validate() error {
 	requiredFields := []string{}
-	if m.MountType == "" {
-		requiredFields = append(requiredFields, "mountType")
-	}
 	if m.Device == "" {
 		requiredFields = append(requiredFields, "device")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Couple of things in this PR:
1. make "type" field in the volume creation request be non-mandatory. This allows bind mounts to be mounted using this volume plugin. 

tested bind mount with this: 
`docker volume create --name efsVolume0 -d amazon-ecs-volume-plugin --opt device=/var/lib/ecs/volumes/efsvolume1 --opt o=bind --opt target=/mnt`

2. When loading state from disk, the in-memory volumes list is updated, but not the structures used for actually storing the state. Changed that. 

Manually tested by stopping the plugin, creating a new volume and making sure the state file contains info of both the old and new volume. 

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
