### PR TITLE
update StartSupervised to survive dockerd outage

### DIFF
--- a/ecs-init/config/logger.go
+++ b/ecs-init/config/logger.go
@@ -34,7 +34,7 @@ and limitations under the License.
 <seelog type="asyncloop">
 	<outputs formatid="main">
 		<console formatid="console" />
-		<rollingfile filename="`+initLogFile()+`" type="date"
+		<rollingfile filename="` + initLogFile() + `" type="date"
 			 datepattern="2006-01-02-15" archivetype="zip" maxrolls="5" />
 	</outputs>
 	<formats>

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -222,7 +222,7 @@ func (c *Client) GetContainerLogTail(logWindowSize string) string {
 	containerToLog, _ := c.findAgentContainer()
 	if containerToLog == "" {
 		log.Info("No existing container to take logs from.")
-                return ""
+		return ""
 	}
 	// we want to capture some logs from our removed containers in case of failure
 	var containerLogBuf bytes.Buffer
@@ -436,6 +436,12 @@ var MatchFilePatternForGPU = FilePatternMatchForGPU
 
 func FilePatternMatchForGPU(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
+}
+
+// Ping checks for availability of dockerd
+func (c *Client) Ping() error {
+	err := c.docker.Ping()
+	return err
 }
 
 // StopAgent stops the Agent in docker if one is running

--- a/ecs-init/engine/dependencies.go
+++ b/ecs-init/engine/dependencies.go
@@ -38,6 +38,7 @@ type dockerClient interface {
 	StartAgent() (int, error)
 	StopAgent() error
 	LoadEnvVars() map[string]string
+	Ping() error
 }
 
 type loopbackRouting interface {

--- a/ecs-init/engine/dependencies_mocks.go
+++ b/ecs-init/engine/dependencies_mocks.go
@@ -257,6 +257,20 @@ func (mr *MockdockerClientMockRecorder) LoadEnvVars() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadEnvVars", reflect.TypeOf((*MockdockerClient)(nil).LoadEnvVars))
 }
 
+// Ping mocks base method
+func (m *MockdockerClient) Ping() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping
+func (mr *MockdockerClientMockRecorder) Ping() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockdockerClient)(nil).Ping))
+}
+
 // MockloopbackRouting is a mock of loopbackRouting interface
 type MockloopbackRouting struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

## Summary
<!-- What does this pull request do? -->
Makes ecs-init daemon resilient to dockerd outages.  
see https://github.com/aws/amazon-ecs-init/issues/231
### Expected Behavior
ecs-init should recover from docker being down for a relative short amount of time (<=5 minutes)

## Implementation details

Currently, the following sections of `StartSupervised` will cause the ecs-init daemon process to exit:
https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/engine/engine.go#L184-L187
If We're unable to reach the docker client (because dockerd is down or is not responding) then we return an error and are kicked out of the main loop.
https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/engine/engine.go#L212-L214
We encounter the `terminalSuccessAgentExitCode` (exit code 0) when the dockerd daemon is killed here:
https://github.com/aws/amazon-ecs-init/blob/master/ecs-init/engine/engine.go#L190

I added a docker client Ping() at the beginning of the main loop to be sure we can reach docker.  If we can't reach docker we'll circle back around and retry the Ping() with backoff.  
I also removed the `return nil` when we encounter the 0 exit code so we aren't kicked out when the agent container goes down.

## Testing
AL2 Testing (with systemd): <In progress>
AL1 Testing (with upstart):
Killed the agent containers directly using `docker kill <ID>`
```
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
$ sudo initctl start ecs
ecs start/running, process 19180
$ docker ps
CONTAINER ID        IMAGE                            COMMAND             CREATED             STATUS                           PORTS               NAMES
d983b652de93        amazon/amazon-ecs-agent:latest   "/agent"            2 seconds ago       Up 1 second (health: starting)                       ecs-agent
$ docker kill d983b652de93
$ docker ps
CONTAINER ID        IMAGE                            COMMAND             CREATED             STATUS                            PORTS               NAMES
285adce82a48        amazon/amazon-ecs-agent:latest   "/agent"            4 seconds ago       Up 3 seconds (health: starting)                       ecs-agent
$ docker kill 285adce82a48
285adce82a48
$ docker ps
CONTAINER ID        IMAGE                            COMMAND             CREATED             STATUS                            PORTS               NAMES
8025c750357b        amazon/amazon-ecs-agent:latest   "/agent"            4 seconds ago       Up 3 seconds (health: starting)                       ecs-agent
```
Next killed the dockerd process then brought it back up
```
$ docker ps
CONTAINER ID        IMAGE                            COMMAND             CREATED             STATUS                            PORTS               NAMES
4455923e8244        amazon/amazon-ecs-agent:latest   "/agent"            3 seconds ago       Up 2 seconds (health: starting)                       ecs-agent
$ docker ps
CONTAINER ID        IMAGE                            COMMAND             CREATED             STATUS                            PORTS               NAMES
ea262edd6fe5        amazon/amazon-ecs-agent:latest   "/agent"            3 seconds ago       Up 2 seconds (health: starting)                       ecs-agent
```
ecs-init.log during execution of the above actions:
```
2020-01-16T19:40:12Z [INFO] pre-start
2020-01-16T19:40:12Z [INFO] start
2020-01-16T19:40:12Z [INFO] Container name: /ecs-agent
2020-01-16T19:40:12Z [INFO] Removing existing agent container ID: b5d00c1d7428e322f9e98ed4fe0342a203a9ee087f8752bad5b8eddf0e076c02
2020-01-16T19:40:12Z [INFO] Starting Amazon Elastic Container Service Agent
2020-01-16T19:40:28Z [INFO] Agent exited with code 137
2020-01-16T19:40:28Z [WARN] ECS Agent container failed to start; retrying in 547.77941ms
2020-01-16T19:40:28Z [INFO] Container name: /ecs-agent
2020-01-16T19:40:28Z [INFO] Removing existing agent container ID: d983b652de93bb184fa1c0b4a7b5ead2622f53591743723cc57e3f86ec84f951
2020-01-16T19:40:28Z [INFO] Starting Amazon Elastic Container Service Agent
2020-01-16T19:40:46Z [INFO] Agent exited with code 137
2020-01-16T19:40:46Z [WARN] ECS Agent container failed to start; retrying in 1.082153551s
2020-01-16T19:40:47Z [INFO] Container name: /ecs-agent
2020-01-16T19:40:47Z [INFO] Removing existing agent container ID: 285adce82a481a12a763c3ff137ec4defa208839e1c48a781d0e5c745c40f96c
2020-01-16T19:40:47Z [INFO] Starting Amazon Elastic Container Service Agent
2020-01-16T19:41:02Z [INFO] Agent exited with code 0
2020-01-16T19:41:02Z [WARN] ECS Agent container failed to start; retrying in 2.066145821s
2020-01-16T19:41:04Z [WARN] Unable to reach dockerd; retrying in 4.235010051s
2020-01-16T19:41:08Z [INFO] Container name: /ecs-agent
2020-01-16T19:41:08Z [INFO] Removing existing agent container ID: 8025c750357b050e4d768c985af567be9c55ae0bbfb573b9972936a11ff961cb
2020-01-16T19:41:08Z [INFO] Starting Amazon Elastic Container Service Agent
2020-01-16T19:41:35Z [INFO] Agent exited with code 0
2020-01-16T19:41:35Z [WARN] Unable to reach dockerd; retrying in 8.287113937s
2020-01-16T19:41:43Z [INFO] Container name: /ecs-agent
2020-01-16T19:41:43Z [INFO] Removing existing agent container ID: 4455923e82449f656de202c748653a0fad8ffb21006d59a3ff972a000a3294cf
2020-01-16T19:41:43Z [INFO] Starting Amazon Elastic Container Service Agent
```

## Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Make ecs-init resilient to dockerd outages

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
