### PR TITLE
return mount path and createdAt for get volume API

### DIFF
--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -91,11 +91,13 @@ func TestVolumeCreateHappyPath(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "efs", vol.Type)
 	assert.Equal(t, VolumeMountPathPrefix+"vol", vol.Path)
+	assert.NotEmpty(t, vol.CreatedAt)
 	assert.Len(t, plugin.state.VolState.Volumes, 1)
 	volInfo, ok := plugin.state.VolState.Volumes["vol"]
 	assert.True(t, ok)
 	assert.Equal(t, "efs", volInfo.Type)
 	assert.Equal(t, VolumeMountPathPrefix+"vol", volInfo.Path)
+	assert.Equal(t, vol.CreatedAt, volInfo.CreatedAt)
 }
 
 func TestVolumeCreateTargetSpecified(t *testing.T) {
@@ -544,7 +546,10 @@ func TestListVolumes(t *testing.T) {
 }
 
 func TestGetVolume(t *testing.T) {
-	vol := &Volume{}
+	vol := &Volume{
+		Path:      "/var/lib/ecs/volume/vol",
+		CreatedAt: "2020-01-17T21:20:04Z",
+	}
 	plugin := &AmazonECSVolumePlugin{
 		volumeDrivers: map[string]VolumeDriver{},
 		volumes: map[string]*Volume{
@@ -557,6 +562,8 @@ func TestGetVolume(t *testing.T) {
 	resp, err := plugin.Get(req)
 	assert.NoError(t, err)
 	assert.Equal(t, "vol1", resp.Volume.Name)
+	assert.Equal(t, vol.Path, resp.Volume.Mountpoint)
+	assert.Equal(t, vol.CreatedAt, resp.Volume.CreatedAt)
 }
 
 func TestGetVolumeError(t *testing.T) {

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -45,9 +45,10 @@ type VolumeState struct {
 
 // VolumeInfo contains the information of managed volumes
 type VolumeInfo struct {
-	Type    string            `json:"type,omitempty"`
-	Path    string            `json:"path,omitempty"`
-	Options map[string]string `json:"options,omitempty"`
+	Type      string            `json:"type,omitempty"`
+	Path      string            `json:"path,omitempty"`
+	Options   map[string]string `json:"options,omitempty"`
+	CreatedAt string            `json:"createdAt,omitempty"`
 }
 
 // NewStateManager initializes the state manager of volume plugin
@@ -61,9 +62,10 @@ func NewStateManager() *StateManager {
 
 func (s *StateManager) recordVolume(volName string, vol *Volume) error {
 	s.VolState.Volumes[volName] = &VolumeInfo{
-		Type:    vol.Type,
-		Path:    vol.Path,
-		Options: vol.Options,
+		Type:      vol.Type,
+		Path:      vol.Path,
+		Options:   vol.Options,
+		CreatedAt: vol.CreatedAt,
 	}
 	return s.save()
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
To get information such as `createdAt` time, mount point for the volume, return it from the plugin. 

Testing:
```
$ docker volume inspect efsvolume0
[
    {
        "CreatedAt": "2020-01-17T21:33:38Z",
        "Driver": "amazon-ecs-volume-plugin",
        "Labels": {},
        "Mountpoint": "/var/lib/ecs/volumes/efsvolume0",
        "Name": "efsvolume0",
        "Options": {
            "device": "fs-1cf5f8b7",
            "o": "tls,ro",
            "type": "efs"
        },
        "Scope": "local"
    }
]
```
State file:
```
$ sudo cat /var/lib/ecs/data/ecs_volume_plugin.json
{
	"volumes": {
		"efsvolume0": {
			"type": "efs",
			"path": "/var/lib/ecs/volumes/efsvolume0",
			"options": {
				"device": "fs-1cf5f8b7",
				"o": "tls,ro",
				"type": "efs"
			},
			"createdAt": "2020-01-17T21:33:38.172301878Z"
		}
	}
}
```

### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
