### PR TITLE
Add script to generate/update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,284 @@
+# Changelog
+
+## 1.36.1-1
+* Cache Agent version 1.36.1
+
+## 1.36.0-1
+* Cache Agent version 1.36.0
+* capture a fixed tail of container logs when removing a container
+
+## 1.35.0-1
+* Cache Agent version 1.35.0
+* Fix bug where stopping agent gracefully would still restart ecs-init
+
+## 1.33.0-1
+* Cache Agent version 1.33.0
+* Fix destination path in docker socket bind mount to match the one specified using DOCKER\_HOST on Amazon Linux 2
+
+## 1.32.1-1
+* Cache Agent version 1.32.1
+* Add the ability to set Agent container's labels
+
+## 1.32.0-1
+* Cache Agent version 1.32.0
+
+## 1.31.0-1
+* Cache Agent version 1.31.0
+
+## 1.30.0-1
+* Cache Agent version 1.30.0
+
+## 1.29.1-1
+* Cache Agent version 1.29.1
+
+## 1.29.0-1
+* Cache Agent version 1.29.0
+
+## 1.28.1-2
+* Cache Agent version 1.28.1
+* Use exponential backoff when restarting agent
+
+## 1.28.0-1
+* Cache Agent version 1.28.0
+
+## 1.27.0-1
+* Cache Agent version 1.27.0
+
+## 1.26.1-1
+* Cache Agent version 1.26.1
+
+## 1.26.0-1
+* Cache Agent version 1.26.0
+* Add support for running iptables within agent container
+
+## 1.25.3-1
+* Cache Agent version 1.25.3
+
+## 1.25.2-1
+* Cache Agent version 1.25.2
+
+## 1.25.1-1
+* Cache Agent version 1.25.1
+* Update ecr models for private link support
+
+## 1.25.0-1
+* Cache Agent version 1.25.0
+* Add Nvidia GPU support for p2 and p3 instances
+
+## 1.24.0-1
+* Cache Agent version 1.24.0
+
+## 1.22.0-4
+* Cache ECS agent version 1.22.0 for x86\_64 & ARM
+* Support ARM architecture builds
+
+## 1.22.0-3
+* Rebuild
+
+## 1.22.0-2
+* Cache Agent version 1.22.0
+
+## 1.21.0-1
+* Cache Agent version 1.21.0
+* Support configurable logconfig for Agent container to reduce disk usage
+* ECS Agent will use the host's cert store on the Amazon Linux platform
+
+## 1.20.3-1
+* Cache Agent version 1.20.3
+
+## 1.20.2-1
+* Cache Agent version 1.20.2
+
+## 1.20.1-1
+* Cache Agent version 1.20.1
+
+## 1.20.0-1
+* Cache Agent version 1.20.0
+
+## 1.19.1-1
+* Cache Agent version 1.19.1
+
+## 1.19.0-1
+* Cache Agent version 1.19.0
+
+## 1.18.0-2
+* Spec file cleanups
+* Enable builds for both AL1 and AL2
+
+## 1.18.0-1
+* Cache Agent version 1.18.0
+* Add support for regional buckets
+* Bundle ECS Agent tarball in package
+* Download agent based on the partition
+* Mount Docker plugin files dir
+
+## 1.17.3-1
+* Cache Agent version 1.17.3
+* Use s3client instead of httpclient when downloading
+
+## 1.17.2-1
+* Cache Agent version 1.17.2
+
+## 1.17.1-1
+* Cache Agent version 1.17.1
+
+## 1.17.0-2
+* Cache Agent version 1.17.0
+
+## 1.16.2-1
+* Cache Agent version 1.16.2
+* Add GovCloud endpoint
+
+## 1.16.1-1
+* Cache Agent version 1.16.1
+* Improve startup behavior when Docker socket doesn't exist yet
+
+## 1.16.0-1
+* Cache Agent version 1.16.0
+
+## 1.15.2-1
+* Cache Agent version 1.15.2
+
+## 1.15.1-1
+* Update ECS Agent version
+
+## 1.15.0-1
+* Update ECS Agent version
+
+## 1.14.5-1
+* Update ECS Agent version
+
+## 1.14.4-1
+* Update ECS Agent version
+
+## 1.14.2-2
+* Cache Agent version 1.14.2
+* Add functionality for running agent with userns=host when Docker has userns-remap enabled
+* Add support for Docker 17.03.1ce
+
+## 1.14.1-1
+* Cache Agent version 1.14.1
+
+## 1.14.0-2
+* Add retry-backoff for pinging the Docker socket when creating the Docker client
+
+## 1.14.0-1
+* Cache Agent version 1.14.0
+
+## 1.13.1-2
+* Update Requires to indicate support for docker <= 1.12.6
+
+## 1.13.1-1
+* Cache Agent version 1.13.1
+
+## 1.13.0-1
+* Cache Agent version 1.13.0
+
+## 1.12.2-1
+* Cache Agent version 1.12.2
+
+## 1.12.1-1
+* Cache Agent version 1.12.1
+
+## 1.12.0-1
+* Cache Agent version 1.12.0
+* Add netfilter rules to support host network reaching credentials proxy
+
+## 1.11.1-1
+* Cache Agent version 1.11.1
+
+## 1.11.0-1
+* Cache Agent version 1.11.0
+* Add support for Docker 1.11.2
+* Modify iptables and netfilter to support credentials proxy
+* Eliminate requirement that /tmp and /var/cache be on the same filesystem
+* Start agent with host network mode
+
+## 1.10.0-1
+* Cache Agent version 1.10.0
+* Add support for Docker 1.11.1
+
+## 1.9.0-1
+* Cache Agent version 1.9.0
+* Make awslogs driver available by default
+
+## 1.8.2-1
+* Cache Agent version 1.8.2
+
+## 1.8.1-1
+* Cache Agent version 1.8.1
+
+## 1.8.0-1
+* Cache Agent version 1.8.0
+
+## 1.7.1-1
+* Cache Agent version 1.7.1
+
+## 1.7.0-1
+* Cache Agent version 1.7.0
+* Add support for Docker 1.9.1
+
+## 1.6.0-1
+* Cache Agent version 1.6.0
+* Updated source dependencies
+
+## 1.5.0-1
+* Cache Agent version 1.5.0
+* Improved merge strategy for user-supplied environment variables
+* Add default supported logging drivers
+
+## 1.4.0-2
+* Add support for Docker 1.7.1
+
+## 1.4.0-1
+* Cache Agent version 1.4.0
+
+## 1.3.1-1
+* Cache Agent version 1.3.1
+* Read Docker endpoint from environment variable DOCKER\_HOST if present
+
+## 1.3.0-1
+* Cache Agent version 1.3.0
+
+## 1.2.1-2
+* Cache Agent version 1.2.1
+
+## 1.2.0-1
+* Update versioning scheme to match Agent version
+* Cache Agent version 1.2.0
+* Mount cgroup and execdriver directories for Telemetry feature
+
+## 1.0-5
+* Add support for Docker 1.6.2
+
+## 1.0-4
+* Properly restart if the ecs-init package is upgraded in isolation
+
+## 1.0-3
+* Restart on upgrade if already running
+
+## 1.0-2
+* Cache Agent version 1.1.0
+* Add support for Docker 1.6.0
+* Force cache load on install/upgrade
+* Add man page
+
+## 1.0-1
+* Re-start Agent on non-terminal exit codes
+* Enable Agent self-updates
+* Cache Agent version 1.0.0
+* Added rollback to cached Agent version for failed updates
+
+## 0.3-0
+* Migrate to statically-compiled Go binary
+
+## 0.2-3
+* Test for existing container agent and force remove it
+
+## 0.2-2
+* Mount data directory for state persistence
+* Enable JSON-based configuration
+
+## 0.2-1
+* Naive update functionality
+

--- a/packaging/suse/amazon-ecs-init.changes
+++ b/packaging/suse/amazon-ecs-init.changes
@@ -1,0 +1,362 @@
+-------------------------------------------------------------------
+Fri Jan 10, 11:00:00 PST 2020 - yhlee@amazon.com - 1.36.1-1
+
+- Cache Agent version 1.36.1
+-------------------------------------------------------------------
+Wed Jan 08, 11:00:00 PST 2020 - cssparr@amazon.com - 1.36.0-1
+
+- Cache Agent version 1.36.0
+- capture a fixed tail of container logs when removing a container
+-------------------------------------------------------------------
+Thu Dec 12, 09:00:00 PST 2019 - petderek@amazon.com - 1.35.0-1
+
+- Cache Agent version 1.35.0
+- Fix bug where stopping agent gracefully would still restart ecs-init
+-------------------------------------------------------------------
+Mon Nov 11, 09:00:00 PST 2019 - shugy@amazon.com - 1.33.0-1
+
+- Cache Agent version 1.33.0
+- Fix destination path in docker socket bind mount to match the one specified using DOCKER_HOST on Amazon Linux 2
+-------------------------------------------------------------------
+Mon Oct 28, 09:00:00 PST 2019 - shugy@amazon.com - 1.32.1-1
+
+- Cache Agent version 1.32.1
+- Add the ability to set Agent container's labels
+-------------------------------------------------------------------
+Wed Sep 25, 10:00:00 PST 2019 - cssparr@amazon.com - 1.32.0-1
+
+- Cache Agent version 1.32.0
+-------------------------------------------------------------------
+Fri Sep 13, 10:00:00 PST 2019 - cya@amazon.com - 1.31.0-1
+
+- Cache Agent version 1.31.0
+-------------------------------------------------------------------
+Thu Aug 15, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.30.0-1
+
+- Cache Agent version 1.30.0
+-------------------------------------------------------------------
+Mon Jul 08, 11:06:00 PST 2019 - shugy@amazon.com - 1.29.1-1
+
+- Cache Agent version 1.29.1
+-------------------------------------------------------------------
+Thu Jun 06, 14:47:00 PST 2019 - yumex@amazon.com - 1.29.0-1
+
+- Cache Agent version 1.29.0
+-------------------------------------------------------------------
+Fri May 31, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.28.1-2
+
+- Cache Agent version 1.28.1
+- Use exponential backoff when restarting agent
+-------------------------------------------------------------------
+Thu May 09, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.28.0-1
+
+- Cache Agent version 1.28.0
+-------------------------------------------------------------------
+Thu Mar 28, 14:00:00 PST 2019 - obo@amazon.com - 1.27.0-1
+
+- Cache Agent version 1.27.0
+-------------------------------------------------------------------
+Thu Mar 21, 13:30:00 PST 2019 - petderek@amazon.com - 1.26.1-1
+
+- Cache Agent version 1.26.1
+-------------------------------------------------------------------
+Thu Feb 28, 13:30:00 PST 2019 - petderek@amazon.com - 1.26.0-1
+
+- Cache Agent version 1.26.0
+- Add support for running iptables within agent container
+-------------------------------------------------------------------
+Fri Feb 15, 11:30:00 PST 2019 - fierlion@amazon.com - 1.25.3-1
+
+- Cache Agent version 1.25.3
+-------------------------------------------------------------------
+Thu Jan 31, 11:53:00 PST 2019 - obo@amazon.com - 1.25.2-1
+
+- Cache Agent version 1.25.2
+-------------------------------------------------------------------
+Fri Jan 25, 20:39:00 PST 2019 - adnkha@amazon.com - 1.25.1-1
+
+- Cache Agent version 1.25.1
+- Update ecr models for private link support
+-------------------------------------------------------------------
+Thu Jan 17, 10:32:18 PST 2019 - yuzhusun@amazon.com - 1.25.0-1
+
+- Cache Agent version 1.25.0
+- Add Nvidia GPU support for p2 and p3 instances
+-------------------------------------------------------------------
+Fri Jan 04, 10:16:18 PST 2019 - yuzhusun@amazon.com - 1.24.0-1
+
+- Cache Agent version 1.24.0
+-------------------------------------------------------------------
+Fri Nov 16, 11:00:00 PST 2018 - jakeev@amazon.com - 1.22.0-4
+
+- Cache ECS agent version 1.22.0 for x86_64 & ARM
+- Support ARM architecture builds
+-------------------------------------------------------------------
+Thu Nov 15, 11:00:00 PST 2018 - jakeev@amazon.com - 1.22.0-3
+
+- Rebuild
+-------------------------------------------------------------------
+Fri Nov 02, 09:51:28 PST 2018 - yhlee@amazon.com - 1.22.0-2
+
+- Cache Agent version 1.22.0
+-------------------------------------------------------------------
+Thu Oct 11, 10:49:28 PST 2018 - sharanyd@amazon.com - 1.21.0-1
+
+- Cache Agent version 1.21.0
+- Support configurable logconfig for Agent container to reduce disk usage
+- ECS Agent will use the host's cert store on the Amazon Linux platform
+-------------------------------------------------------------------
+Thu Sep 13, 16:38:10 PST 2018 - yumex@amazon.com - 1.20.3-1
+
+- Cache Agent version 1.20.3
+-------------------------------------------------------------------
+Thu Aug 30, 16:43:01 PST 2018 - fenxiong@amazon.com - 1.20.2-1
+
+- Cache Agent version 1.20.2
+-------------------------------------------------------------------
+Wed Aug 08, 16:04:01 PST 2018 - penyin@amazon.com - 1.20.1-1
+
+- Cache Agent version 1.20.1
+-------------------------------------------------------------------
+Wed Aug 01, 15:44:01 PST 2018 - haikuo@amazon.com - 1.20.0-1
+
+- Cache Agent version 1.20.0
+-------------------------------------------------------------------
+Thu Jul 26, 13:31:24 PST 2018 - haikuo@amazon.com - 1.19.1-1
+
+- Cache Agent version 1.19.1
+-------------------------------------------------------------------
+Thu Jul 19, 15:09:41 PST 2018 - fenxiong@amazon.com - 1.19.0-1
+
+- Cache Agent version 1.19.0
+-------------------------------------------------------------------
+Wed May 23, 11:00:00 PST 2018 - iweller@amazon.com - 1.18.0-2
+
+- Spec file cleanups
+- Enable builds for both AL1 and AL2
+-------------------------------------------------------------------
+Fri May 04, 13:30:22 PST 2018 - haikuo@amazon.com - 1.18.0-1
+
+- Cache Agent version 1.18.0
+- Add support for regional buckets
+- Bundle ECS Agent tarball in package
+- Download agent based on the partition
+- Mount Docker plugin files dir
+-------------------------------------------------------------------
+Fri Mar 30, 12:20:41 PST 2018 - jushay@amazon.com - 1.17.3-1
+
+- Cache Agent version 1.17.3
+- Use s3client instead of httpclient when downloading
+-------------------------------------------------------------------
+Mon Mar 05, 10:31:19 PST 2018 - jakeev@amazon.com - 1.17.2-1
+
+- Cache Agent version 1.17.2
+-------------------------------------------------------------------
+Mon Feb 19, 10:57:33 PST 2018 - jushay@amazon.com - 1.17.1-1
+
+- Cache Agent version 1.17.1
+-------------------------------------------------------------------
+Mon Feb 05, 10:03:33 PST 2018 - jushay@amazon.com - 1.17.0-2
+
+- Cache Agent version 1.17.0
+-------------------------------------------------------------------
+Tue Jan 16, 10:12:56 PST 2018 - petderek@amazon.com - 1.16.2-1
+
+- Cache Agent version 1.16.2
+- Add GovCloud endpoint
+-------------------------------------------------------------------
+Wed Jan 03, 14:52:56 PST 2018 - nmeyerha@amazon.com - 1.16.1-1
+
+- Cache Agent version 1.16.1
+- Improve startup behavior when Docker socket doesn't exist yet
+-------------------------------------------------------------------
+Tue Nov 21, 13:03:59 PST 2017 - nmeyerha@amazon.com - 1.16.0-1
+
+- Cache Agent version 1.16.0
+-------------------------------------------------------------------
+Tue Nov 14, 16:53:54 PST 2017 - nmeyerha@amazon.com - 1.15.2-1
+
+- Cache Agent version 1.15.2
+-------------------------------------------------------------------
+Tue Oct 17, 07:55:19 PST 2017 - jakeev@amazon.com - 1.15.1-1
+
+- Update ECS Agent version
+-------------------------------------------------------------------
+Fri Oct 06, 23:50:23 PST 2017 - jushay@amazon.com - 1.15.0-1
+
+- Update ECS Agent version
+-------------------------------------------------------------------
+Fri Sep 29, 17:36:34 PST 2017 - jushay@amazon.com - 1.14.5-1
+
+- Update ECS Agent version
+-------------------------------------------------------------------
+Tue Aug 22, 15:44:03 PST 2017 - jushay@amazon.com - 1.14.4-1
+
+- Update ECS Agent version
+-------------------------------------------------------------------
+Thu Jun 01, 11:00:00 PST 2017 - adnkha@amazon.com - 1.14.2-2
+
+- Cache Agent version 1.14.2
+- Add functionality for running agent with userns=host when Docker has userns-remap enabled
+- Add support for Docker 17.03.1ce
+-------------------------------------------------------------------
+Mon Mar 06, 11:00:00 PST 2017 - adnkha@amazon.com - 1.14.1-1
+
+- Cache Agent version 1.14.1
+-------------------------------------------------------------------
+Wed Jan 25, 11:00:00 PST 2017 - aithal@amazon.com - 1.14.0-2
+
+- Add retry-backoff for pinging the Docker socket when creating the Docker client
+-------------------------------------------------------------------
+Mon Jan 16, 11:00:00 PST 2017 - petderek@amazon.com - 1.14.0-1
+
+- Cache Agent version 1.14.0
+-------------------------------------------------------------------
+Fri Jan 06, 11:00:00 PST 2017 - nmeyerha@amazon.com - 1.13.1-2
+
+- Update Requires to indicate support for docker <= 1.12.6
+-------------------------------------------------------------------
+Mon Nov 14, 11:00:00 PST 2016 - penyin@amazon.com - 1.13.1-1
+
+- Cache Agent version 1.13.1
+-------------------------------------------------------------------
+Tue Sep 27, 11:00:00 PST 2016 - nmeyerha@amazon.com - 1.13.0-1
+
+- Cache Agent version 1.13.0
+-------------------------------------------------------------------
+Tue Sep 13, 11:00:00 PST 2016 - aithal@amazon.com - 1.12.2-1
+
+- Cache Agent version 1.12.2
+-------------------------------------------------------------------
+Wed Aug 17, 11:00:00 PST 2016 - penyin@amazon.com - 1.12.1-1
+
+- Cache Agent version 1.12.1
+-------------------------------------------------------------------
+Wed Aug 10, 11:00:00 PST 2016 - aithal@amazon.com - 1.12.0-1
+
+- Cache Agent version 1.12.0
+- Add netfilter rules to support host network reaching credentials proxy
+-------------------------------------------------------------------
+Wed Aug 03, 11:00:00 PST 2016 - skarp@amazon.com - 1.11.1-1
+
+- Cache Agent version 1.11.1
+-------------------------------------------------------------------
+Tue Jul 05, 11:00:00 PST 2016 - skarp@amazon.com - 1.11.0-1
+
+- Cache Agent version 1.11.0
+- Add support for Docker 1.11.2
+- Modify iptables and netfilter to support credentials proxy
+- Eliminate requirement that /tmp and /var/cache be on the same filesystem
+- Start agent with host network mode
+-------------------------------------------------------------------
+Mon May 23, 11:00:00 PST 2016 - penyin@amazon.com - 1.10.0-1
+
+- Cache Agent version 1.10.0
+- Add support for Docker 1.11.1
+-------------------------------------------------------------------
+Tue Apr 26, 11:00:00 PST 2016 - penyin@amazon.com - 1.9.0-1
+
+- Cache Agent version 1.9.0
+- Make awslogs driver available by default
+-------------------------------------------------------------------
+Thu Mar 24, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.2-1
+
+- Cache Agent version 1.8.2
+-------------------------------------------------------------------
+Mon Feb 29, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.1-1
+
+- Cache Agent version 1.8.1
+-------------------------------------------------------------------
+Wed Feb 10, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.0-1
+
+- Cache Agent version 1.8.0
+-------------------------------------------------------------------
+Fri Jan 08, 11:00:00 PST 2016 - skarp@amazon.com - 1.7.1-1
+
+- Cache Agent version 1.7.1
+-------------------------------------------------------------------
+Tue Dec 08, 11:00:00 PST 2015 - skarp@amazon.com - 1.7.0-1
+
+- Cache Agent version 1.7.0
+- Add support for Docker 1.9.1
+-------------------------------------------------------------------
+Wed Oct 21, 11:00:00 PST 2015 - skarp@amazon.com - 1.6.0-1
+
+- Cache Agent version 1.6.0
+- Updated source dependencies
+-------------------------------------------------------------------
+Wed Sep 23, 11:00:00 PST 2015 - skarp@amazon.com - 1.5.0-1
+
+- Cache Agent version 1.5.0
+- Improved merge strategy for user-supplied environment variables
+- Add default supported logging drivers
+-------------------------------------------------------------------
+Wed Aug 26, 11:00:00 PST 2015 - skarp@amazon.com - 1.4.0-2
+
+- Add support for Docker 1.7.1
+-------------------------------------------------------------------
+Tue Aug 11, 11:00:00 PST 2015 - skarp@amazon.com - 1.4.0-1
+
+- Cache Agent version 1.4.0
+-------------------------------------------------------------------
+Thu Jul 30, 11:00:00 PST 2015 - skarp@amazon.com - 1.3.1-1
+
+- Cache Agent version 1.3.1
+- Read Docker endpoint from environment variable DOCKER_HOST if present
+-------------------------------------------------------------------
+Thu Jul 02, 11:00:00 PST 2015 - skarp@amazon.com - 1.3.0-1
+
+- Cache Agent version 1.3.0
+-------------------------------------------------------------------
+Fri Jun 19, 11:00:00 PST 2015 - euank@amazon.com - 1.2.1-2
+
+- Cache Agent version 1.2.1
+-------------------------------------------------------------------
+Tue Jun 02, 11:00:00 PST 2015 - skarp@amazon.com - 1.2.0-1
+
+- Update versioning scheme to match Agent version
+- Cache Agent version 1.2.0
+- Mount cgroup and execdriver directories for Telemetry feature
+-------------------------------------------------------------------
+Mon Jun 01, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-5
+
+- Add support for Docker 1.6.2
+-------------------------------------------------------------------
+Mon May 11, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-4
+
+- Properly restart if the ecs-init package is upgraded in isolation
+-------------------------------------------------------------------
+Wed May 06, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-3
+
+- Restart on upgrade if already running
+-------------------------------------------------------------------
+Tue May 05, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-2
+
+- Cache Agent version 1.1.0
+- Add support for Docker 1.6.0
+- Force cache load on install/upgrade
+- Add man page
+-------------------------------------------------------------------
+Thu Mar 26, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-1
+
+- Re-start Agent on non-terminal exit codes
+- Enable Agent self-updates
+- Cache Agent version 1.0.0
+- Added rollback to cached Agent version for failed updates
+-------------------------------------------------------------------
+Mon Mar 16, 11:00:00 PST 2015 - skarp@amazon.com - 0.3-0
+
+- Migrate to statically-compiled Go binary
+-------------------------------------------------------------------
+Tue Feb 17, 11:00:00 PST 2015 - ericn@amazon.com - 0.2-3
+
+- Test for existing container agent and force remove it
+-------------------------------------------------------------------
+Thu Jan 15, 11:00:00 PST 2015 - skarp@amazon.com - 0.2-2
+
+- Mount data directory for state persistence
+- Enable JSON-based configuration
+-------------------------------------------------------------------
+Mon Dec 15, 11:00:00 PST 2014 - skarp@amazon.com - 0.2-1
+
+- Naive update functionality

--- a/scripts/changelog/CHANGELOG_MASTER
+++ b/scripts/changelog/CHANGELOG_MASTER
@@ -1,0 +1,446 @@
+1.36.1-1
+Yunhee Lee <yhlee@amazon.com>
+Fri, 10 Jan 2020 11:00:00 PST
+Cache Agent version 1.36.1
+
+1.36.0-1
+Cameron Sparr <cssparr@amazon.com>
+Wed, 08 Jan 2020 11:00:00 PST
+Cache Agent version 1.36.0
+capture a fixed tail of container logs when removing a container
+
+1.35.0-1
+Derek Petersen <petderek@amazon.com>
+Thu, 12 Dec 2019 09:00:00 PST
+Cache Agent version 1.35.0
+Fix bug where stopping agent gracefully would still restart ecs-init
+
+1.33.0-1
+Shubham Goyal <shugy@amazon.com>
+Mon, 11 Nov 2019 09:00:00 PST
+Cache Agent version 1.33.0
+Fix destination path in docker socket bind mount to match the one specified using DOCKER_HOST on Amazon Linux 2
+
+1.32.1-1
+Shubham Goyal <shugy@amazon.com>
+Mon, 28 Oct 2019 09:00:00 PST
+Cache Agent version 1.32.1
+Add the ability to set Agent container's labels
+
+1.32.0-1
+Cameron Sparr <cssparr@amazon.com>
+Wed, 25 Sep 2019 10:00:00 PST
+Cache Agent version 1.32.0
+
+1.31.0-1
+Yajie Chu <cya@amazon.com>
+Fri, 13 Sep 2019 10:00:00 PST
+Cache Agent version 1.31.0
+
+1.30.0-1
+Feng Xiong <fenxiong@amazon.com>
+Thu, 15 Aug 2019 10:00:00 PST
+Cache Agent version 1.30.0
+
+1.29.1-1
+Shubham Goyal <shugy@amazon.com>
+Mon, 08 Jul 2019 11:06:00 PST
+Cache Agent version 1.29.1
+
+1.29.0-1
+Yumeng Xie <yumex@amazon.com>
+Thu, 06 Jun 2019 14:47:00 PST
+Cache Agent version 1.29.0
+
+1.28.1-2
+Feng Xiong <fenxiong@amazon.com>
+Fri, 31 May 2019 10:00:00 PST
+Cache Agent version 1.28.1
+Use exponential backoff when restarting agent
+
+1.28.0-1
+Feng Xiong <fenxiong@amazon.com>
+Thu, 09 May 2019 10:00:00 PST
+Cache Agent version 1.28.0
+
+1.27.0-1
+Shaobo Han <obo@amazon.com>
+Thu, 28 Mar 2019 14:00:00 PST
+Cache Agent version 1.27.0
+
+1.26.1-1
+Derek Petersen <petderek@amazon.com>
+Thu, 21 Mar 2019 13:30:00 PST
+Cache Agent version 1.26.1
+
+1.26.0-1
+Derek Petersen <petderek@amazon.com>
+Thu, 28 Feb 2019 13:30:00 PST
+Cache Agent version 1.26.0
+Add support for running iptables within agent container
+
+1.25.3-1
+Ray Allan <fierlion@amazon.com>
+Fri, 15 Feb 2019 11:30:00 PST
+Cache Agent version 1.25.3
+
+1.25.2-1
+Shaobo Han <obo@amazon.com>
+Thu, 31 Jan 2019 11:53:00 PST
+Cache Agent version 1.25.2
+
+1.25.1-1
+Adnan Khan <adnkha@amazon.com>
+Fri, 25 Jan 2019 20:39:00 PST
+Cache Agent version 1.25.1
+Update ecr models for private link support
+
+1.25.0-1
+Eric Sun <yuzhusun@amazon.com>
+Thu, 17 Jan 2019 10:32:18 PST
+Cache Agent version 1.25.0
+Add Nvidia GPU support for p2 and p3 instances
+
+1.24.0-1
+Eric Sun <yuzhusun@amazon.com>
+Fri, 04 Jan 2019 10:16:18 PST
+Cache Agent version 1.24.0
+
+1.22.0-4
+Jacob Vallejo <jakeev@amazon.com>
+Fri, 16 Nov 2018 11:00:00 PST
+Cache ECS agent version 1.22.0 for x86_64 & ARM
+Support ARM architecture builds
+
+1.22.0-3
+Jacob Vallejo <jakeev@amazon.com> 
+Thu, 15 Nov 2018 11:00:00 PST
+Rebuild
+
+1.22.0-2
+Yunhee Lee <yhlee@amazon.com>
+Fri, 02 Nov 2018 09:51:28 PST
+Cache Agent version 1.22.0
+
+1.21.0-1
+Sharanya Devaraj <sharanyd@amazon.com>
+Thu, 11 Oct 2018 10:49:28 PST
+Cache Agent version 1.21.0
+Support configurable logconfig for Agent container to reduce disk usage
+ECS Agent will use the host's cert store on the Amazon Linux platform
+
+1.20.3-1
+Yumeng Xie <yumex@amazon.com>
+Thu, 13 Sep 2018 16:38:10 PST
+Cache Agent version 1.20.3
+
+1.20.2-1
+Feng Xiong <fenxiong@amazon.com>
+Thu, 30 Aug 2018 16:43:01 PST
+Cache Agent version 1.20.2
+
+1.20.1-1
+Peng Yin <penyin@amazon.com>
+Wed, 08 Aug 2018 16:04:01 PST
+Cache Agent version 1.20.1
+
+1.20.0-1
+Haikuo Liu <haikuo@amazon.com>
+Wed, 01 Aug 2018 15:44:01 PST
+Cache Agent version 1.20.0
+
+1.19.1-1
+Haikuo Liu <haikuo@amazon.com>
+Thu, 26 Jul 2018 13:31:24 PST
+Cache Agent version 1.19.1
+
+1.19.0-1
+Feng Xiong <fenxiong@amazon.com>
+Thu, 19 Jul 2018 15:09:41 PST
+Cache Agent version 1.19.0
+
+1.18.0-2
+iliana weller <iweller@amazon.com> 
+Wed, 23 May 2018 11:00:00 PST
+Spec file cleanups
+Enable builds for both AL1 and AL2
+
+1.18.0-1
+Haikuo Liu <haikuo@amazon.com>
+Fri, 04 May 2018 13:30:22 PST
+Cache Agent version 1.18.0
+Add support for regional buckets
+Bundle ECS Agent tarball in package
+Download agent based on the partition
+Mount Docker plugin files dir
+
+1.17.3-1
+Justin Haynes <jushay@amazon.com>
+Fri, 30 Mar 2018 12:20:41 PST
+Cache Agent version 1.17.3
+Use s3client instead of httpclient when downloading
+
+1.17.2-1
+Jacob Vallejo <jakeev@amazon.com>
+Mon, 05 Mar 2018 10:31:19 PST
+Cache Agent version 1.17.2
+
+1.17.1-1
+Justin Haynes <jushay@amazon.com>
+Mon, 19 Feb 2018 10:57:33 PST
+Cache Agent version 1.17.1
+
+1.17.0-2
+Justin Haynes <jushay@amazon.com>
+Mon, 05 Feb 2018 10:03:33 PST
+Cache Agent version 1.17.0
+
+1.16.2-1
+Derek Petersen <petderek@amazon.com>
+Tue, 16 Jan 2018 10:12:56 PST
+Cache Agent version 1.16.2
+Add GovCloud endpoint
+
+1.16.1-1
+Noah Meyerhans <nmeyerha@amazon.com>
+Wed, 03 Jan 2018 14:52:56 PST
+Cache Agent version 1.16.1
+Improve startup behavior when Docker socket doesn't exist yet
+
+1.16.0-1
+Noah Meyerhans <nmeyerha@amazon.com>
+Tue, 21 Nov 2017 13:03:59 PST
+Cache Agent version 1.16.0
+
+1.15.2-1
+Noah Meyerhans <nmeyerha@amazon.com>
+Tue, 14 Nov 2017 16:53:54 PST
+Cache Agent version 1.15.2
+
+1.15.1-1
+Jacob Vallejo <jakeev@amazon.com>
+Tue, 17 Oct 2017 07:55:19 PST
+Update ECS Agent version
+
+1.15.0-1
+Justin Haynes <jushay@amazon.com>
+Mon, 06 Oct 2017 23:50:23 PST
+Update ECS Agent version
+
+1.14.5-1
+Justin Haynes <jushay@amazon.com>
+Fri, 29 Sep 2017 17:36:34 PST
+Update ECS Agent version
+
+1.14.4-1
+Justin Haynes <jushay@amazon.com>
+Wed, 22 Aug 2017 15:44:03 PST
+Update ECS Agent version
+
+1.14.2-2
+Adnan Khan <adnkha@amazon.com>
+Thu, 01 Jun 2017 11:00:00 PST
+Cache Agent version 1.14.2
+Add functionality for running agent with userns=host when Docker has userns-remap enabled
+Add support for Docker 17.03.1ce
+
+1.14.1-1
+Adnan Khan <adnkha@amazon.com>
+Mon, 06 Mar 2017 11:00:00 PST
+Cache Agent version 1.14.1
+
+1.14.0-2
+Anirudh Aithal <aithal@amazon.com>
+Wed, 25 Jan 2017 11:00:00 PST
+Add retry-backoff for pinging the Docker socket when creating the Docker client
+
+1.14.0-1
+Derek Petersen <petderek@amazon.com>
+Mon, 16 Jan 2017 11:00:00 PST
+Cache Agent version 1.14.0
+
+1.13.1-2
+Noah Meyerhans <nmeyerha@amazon.com>
+Fri, 06 Jan 2017 11:00:00 PST
+Update Requires to indicate support for docker <= 1.12.6
+
+1.13.1-1
+Peng Yin <penyin@amazon.com>
+Mon, 14 Nov 2016 11:00:00 PST
+Cache Agent version 1.13.1
+
+1.13.0-1
+Noah Meyerhans <nmeyerha@amazon.com>
+Tue, 27 Sep 2016 11:00:00 PST
+Cache Agent version 1.13.0
+
+1.12.2-1
+Anirudh Aithal <aithal@amazon.com>
+Tue, 13 Sep 2016 11:00:00 PST
+Cache Agent version 1.12.2
+
+1.12.1-1
+Peng Yin <penyin@amazon.com>
+Wed, 17 Aug 2016 11:00:00 PST
+Cache Agent version 1.12.1
+
+1.12.0-1
+Anirudh Aithal <aithal@amazon.com>
+Wed, 10 Aug 2016 11:00:00 PST
+Cache Agent version 1.12.0
+Add netfilter rules to support host network reaching credentials proxy
+
+1.11.1-1
+Samuel Karp <skarp@amazon.com>
+Wed, 03 Aug 2016 11:00:00 PST
+Cache Agent version 1.11.1
+
+1.11.0-1
+Samuel Karp <skarp@amazon.com>
+Tue, 05 Jul 2016 11:00:00 PST
+Cache Agent version 1.11.0
+Add support for Docker 1.11.2
+Modify iptables and netfilter to support credentials proxy
+Eliminate requirement that /tmp and /var/cache be on the same filesystem
+Start agent with host network mode
+
+1.10.0-1
+Peng Yin <penyin@amazon.com>
+Mon, 23 May 2016 11:00:00 PST
+Cache Agent version 1.10.0
+Add support for Docker 1.11.1
+
+1.9.0-1
+Peng Yin <penyin@amazon.com>
+Tue, 26 Apr 2016 11:00:00 PST
+Cache Agent version 1.9.0
+Make awslogs driver available by default
+
+1.8.2-1
+Juan Rhenals <rhenalsj@amazon.com>
+Thu, 24 Mar 2016 11:00:00 PST
+Cache Agent version 1.8.2
+
+1.8.1-1
+Juan Rhenals <rhenalsj@amazon.com>
+Mon, 29 Feb 2016 11:00:00 PST
+Cache Agent version 1.8.1
+
+1.8.0-1
+Juan Rhenals <rhenalsj@amazon.com>
+Wed, 10 Feb 2016 11:00:00 PST
+Cache Agent version 1.8.0
+
+1.7.1-1
+Samuel Karp <skarp@amazon.com>
+Fri, 08 Jan 2016 11:00:00 PST
+Cache Agent version 1.7.1
+
+1.7.0-1
+Samuel Karp <skarp@amazon.com>
+Tue, 08 Dec 2015 11:00:00 PST
+Cache Agent version 1.7.0
+Add support for Docker 1.9.1
+
+1.6.0-1
+Samuel Karp <skarp@amazon.com>
+Wed, 21 Oct 2015 11:00:00 PST
+Cache Agent version 1.6.0
+Updated source dependencies
+
+1.5.0-1
+Samuel Karp <skarp@amazon.com>
+Wed, 23 Sep 2015 11:00:00 PST
+Cache Agent version 1.5.0
+Improved merge strategy for user-supplied environment variables
+Add default supported logging drivers
+
+1.4.0-2
+Samuel Karp <skarp@amazon.com>
+Wed, 26 Aug 2015 11:00:00 PST
+Add support for Docker 1.7.1
+
+1.4.0-1
+Samuel Karp <skarp@amazon.com>
+Tue, 11 Aug 2015 11:00:00 PST
+Cache Agent version 1.4.0
+
+1.3.1-1
+Samuel Karp <skarp@amazon.com>
+Thu, 30 Jul 2015 11:00:00 PST
+Cache Agent version 1.3.1
+Read Docker endpoint from environment variable DOCKER_HOST if present
+
+1.3.0-1
+Samuel Karp <skarp@amazon.com>
+Thu, 02 Jul 2015 11:00:00 PST
+Cache Agent version 1.3.0
+
+1.2.1-2
+Euan Kemp <euank@amazon.com>
+Fri, 19 Jun 2015 11:00:00 PST
+Cache Agent version 1.2.1
+
+1.2.0-1
+Samuel Karp <skarp@amazon.com>
+Tue, 02 Jun 2015 11:00:00 PST
+Update versioning scheme to match Agent version
+Cache Agent version 1.2.0
+Mount cgroup and execdriver directories for Telemetry feature
+
+1.0-5
+Samuel Karp <skarp@amazon.com>
+Mon, 01 Jun 2015 11:00:00 PST
+Add support for Docker 1.6.2
+
+1.0-4
+Samuel Karp <skarp@amazon.com>
+Mon, 11 May 2015 11:00:00 PST
+Properly restart if the ecs-init package is upgraded in isolation
+
+1.0-3
+Samuel Karp <skarp@amazon.com>
+Wed, 06 May 2015 11:00:00 PST
+Restart on upgrade if already running
+
+1.0-2
+Samuel Karp <skarp@amazon.com>
+Tue, 05 May 2015 11:00:00 PST
+Cache Agent version 1.1.0
+Add support for Docker 1.6.0
+Force cache load on install/upgrade
+Add man page
+
+1.0-1
+Samuel Karp <skarp@amazon.com>
+Thu, 26 Mar 2015 11:00:00 PST
+Re-start Agent on non-terminal exit codes
+Enable Agent self-updates
+Cache Agent version 1.0.0
+Added rollback to cached Agent version for failed updates
+
+0.3-0
+Samuel Karp <skarp@amazon.com>
+Mon, 16 Mar 2015 11:00:00 PST
+Migrate to statically-compiled Go binary
+
+0.2-3
+Eric Nordlund <ericn@amazon.com>
+Tue, 17 Feb 2015 11:00:00 PST
+Test for existing container agent and force remove it
+
+0.2-2
+Samuel Karp <skarp@amazon.com>
+Thu, 15 Jan 2015 11:00:00 PST
+Mount data directory for state persistence
+Enable JSON-based configuration
+
+0.2-1
+Samuel Karp <skarp@amazon.com>
+Mon, 15 Dec 2014 11:00:00 PST
+Naive update functionality
+
+0.2-0
+Samuel Karp <skarp@amazon.com>
+Thu, 11 Dec 2014 11:00:00 PST
+Initial version

--- a/scripts/changelog/README.md
+++ b/scripts/changelog/README.md
@@ -1,0 +1,43 @@
+# Update Changelog
+
+## Be sure your git is clean
+We'll be relying on git to guard us against problems.
+Staring from a clean checkout follow these steps.
+ 
+## Update CHANGELOG\_MASTER
+The CHANGELOG\_MASTER consists of 
+
+version (Name.Version.Release) 
+User <user@email>
+Datetime(RFC1123 format) 
+List of changes separated by newline
+Newline
+
+```
+1.32.1-1
+Shubham Goyal <shugy@amazon.com>
+Mon, 28 Oct 2019 09:00:00 PST
+Cache Agent version 1.32.1
+Add the ability to set Agent container's labels
+```
+
+You'll need to add a new entry to the CHANGELOG\_MASTER before running the
+chagelog.go script
+
+## Build and run changelog.go
+From the scripts/changelog dir, build the changelog binary with `go build changelog.go`
+run the built changelog binary from this same directory.  It uses relative
+paths to replace the relevant changelog files: `./changelog`
+
+use git status to check that the following files are updated
+```
+modified:   ../../packaging/amazon-linux-ami/ecs-init.spec
+modified:   ../../packaging/ubuntu-trusty/debian/changelog
+modified:   ../../packaging/suse/amazon-ecs-init.changes
+modified:   ../../CHANGELOG.md
+```
+use `git diff` to be sure that the change is what you expect.  Pay special
+attention to the date.
+
+add and commit the updated changelog files and then delete the built changelog
+binary.

--- a/scripts/changelog/changelog.go
+++ b/scripts/changelog/changelog.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+    "strings"
+    "time"
+)
+
+type Change struct {
+    Version string
+    Name string
+    Datetime time.Time
+    Changes []string
+}
+
+const (
+    CHANGE_TEMPLATE = "./CHANGELOG_MASTER"
+    TOP_LEVEL = "../../CHANGELOG.md"
+    AMAZON_LINUX = "../../packaging/amazon-linux-ami/ecs-init.spec"
+    SUSE = "../../packaging/suse/amazon-ecs-init.changes"
+    UBUNTU = "../../packaging/ubuntu-trusty/debian/changelog"
+
+    AMAZON_LINUX_TIME_FMT = "Mon Jan 02 2006"
+    DEBIAN_TIME_FMT = "Mon, 02 Jan 2006 15:04:05 -0700"
+    SUSE_TIME_FMT = "Mon Jan 02, 15:04:05 MST 2006"
+
+    PST_CONV = "-0800"
+)
+
+func main() {
+    templateFile, err := os.Open(CHANGE_TEMPLATE)
+    handleErr(err, "unable to open CHANGE_TEMPLATE")
+    defer templateFile.Close()
+
+    // parse CHANGE_TEMPLATE
+    // TODO add validation dates in ascending order
+    // TODO add validation no duplicate versions
+    scanner := bufio.NewScanner(templateFile)
+    changeArray := []Change{}
+    changeStrings := []string{}
+    for scanner.Scan() {
+        thisText := scanner.Text()
+        if thisText == "" {
+            currentChanges := []string{}
+            // parse the remaining array of changes
+            for i := 3; i< len(changeStrings); i++ {
+                currentChanges = append(currentChanges, changeStrings[i])
+            }
+            thisTime, err := time.Parse(time.RFC1123, changeStrings[2])
+            handleErr(err, "error parsing time")
+            thisChange := Change{changeStrings[0],
+                          changeStrings[1],
+                          thisTime,
+                          currentChanges,
+                      }
+            changeArray = append(changeArray, thisChange)
+            changeStrings = []string{}
+        } else {
+            changeStrings = append(changeStrings, thisText)
+        }
+    }
+
+    // Create formatted strings for each log
+    amazonLinuxChangeString := getAmazonLinuxChangeString(changeArray)
+    ubuntuChangeString := getUbuntuChangeString(changeArray)
+    suseChangeString := getSuseChangeString(changeArray)
+    topLevelChangeString := getTopLevelChangeString(changeArray)
+
+    // update changelog files
+    rewriteChangelog(TOP_LEVEL, topLevelChangeString)
+    rewriteChangelog(UBUNTU, ubuntuChangeString)
+    rewriteChangelog(SUSE, suseChangeString)
+
+    // find changelog in AmazonLinux rpm spec
+    var amazonLinuxSpecBase = ""
+    if _, err := os.Stat(AMAZON_LINUX); err == nil {
+        f, err := os.Open(AMAZON_LINUX)
+        handleErr(err, "unable to open amazon linux changelog")
+        defer f.Close()
+        scanner := bufio.NewScanner(f)
+        for scanner.Scan() {
+            line := scanner.Text()
+            if strings.Contains(line, "%changelog") {
+                amazonLinuxSpecBase += fmt.Sprintln("%changelog")
+                break
+            }
+            amazonLinuxSpecBase += fmt.Sprintln(line)
+        }
+    }
+    completeAmazonLinuxChangeString := amazonLinuxSpecBase + amazonLinuxChangeString
+    rewriteChangelog(AMAZON_LINUX, completeAmazonLinuxChangeString)
+ }
+
+// format as follows:
+//
+// * Wed Jan 08 2020 Cameron Sparr <cssparr@amazon.com> - 1.36.0-1
+// - Cache Agent version 1.36.0
+// - Capture a fixed tail of container logs when removing a container
+func getAmazonLinuxChangeString(allChange []Change) string {
+    result := ""
+    for _, change := range allChange {
+        thisTime := change.Datetime.Format(AMAZON_LINUX_TIME_FMT)
+        result += fmt.Sprintf("* %s %s - %s\n", thisTime, change.Name, change.Version)
+        for _, update := range change.Changes {
+            result += fmt.Sprintf("- %s\n", update)
+        }
+        result += fmt.Sprintln()
+    }
+    return result
+}
+
+// format as follows:
+//
+// amazon-ecs-init (1.36.0-1) trusty; urgency=medium
+//
+//  * Cache Agent version 1.36.0
+//  * capture a fixed tail of container logs when removing a container
+//
+//  -- Cameron Sparr <cssparr@amazon.com> Wed, 08 Jan 2020 11:00:00 -0800
+func getUbuntuChangeString(allChange []Change) string {
+    result := ""
+    for _, change := range allChange {
+        result += fmt.Sprintf("amazon-ecs-init (%s) trusty; urgency=medium\n\n", change.Version)
+        thisTime := change.Datetime.Format(DEBIAN_TIME_FMT)
+        // fix bug where time doesn't parse 'PST' to '-0800'
+        r := strings.NewReplacer("+0000", PST_CONV)
+        thisTime = r.Replace(thisTime)
+        for _, update := range change.Changes {
+            result += fmt.Sprintf("  * %s\n", update)
+        }
+        result += fmt.Sprintln()
+        result += fmt.Sprintf(" -- %s  %s\n", change.Name, thisTime)
+        result += fmt.Sprintln()
+    }
+    return result
+}
+
+// format as follows
+// -------------------------------------------------------------------
+// Tue Apr 22 20:54:26 UTC 2013 - your@email.com
+//
+// - level 1 bullet point; long descriptions
+//   should wrap
+// - another l1 bullet point
+func getSuseChangeString(allChange []Change) string {
+    result := ""
+    for _, change := range allChange {
+        result += fmt.Sprintf("-------------------------------------------------------------------\n")
+        thisTime := change.Datetime.Format(SUSE_TIME_FMT)
+        thisEmail := getEmailSlice(change.Name)
+        result += fmt.Sprintf("%s - %s - %s\n\n", thisTime, thisEmail, change.Version)
+        for _, update := range change.Changes {
+            result += fmt.Sprintf("- %s\n", update)
+        }
+    }
+    return result
+}
+
+// format as follows
+//
+//  ## 1.35.0
+//  * Cache Agent version 1.36.0
+//  * capture a fixed tail of container logs when removing a container
+func getTopLevelChangeString(allChange []Change) string {
+    result := "# Changelog\n\n"
+    for _, change := range allChange {
+        result += fmt.Sprintf("## %s\n", change.Version)
+        for _, update := range change.Changes {
+            result += fmt.Sprintf("* %s\n", update)
+        }
+        result += fmt.Sprintln()
+    }
+    // escape special char for .md
+    r := strings.NewReplacer("_", "\\_")
+    result = r.Replace(result)
+    return result
+}
+
+// update changelog files
+// removes original file, creates updated file
+func rewriteChangelog(changelogFile string, updateString string) {
+    if _, err := os.Stat(changelogFile); err == nil {
+        err := os.Remove(changelogFile)
+        handleErr(err, "unable to remove changelog file")
+        f, err := os.Create(changelogFile)
+        handleErr(err, "unable to create changelog file")
+        defer f.Close()
+        _, err = f.WriteString(updateString)
+        handleErr(err, "unable to write string to changelog file")
+    }
+}
+
+// Simple error print.  Passthough if err is nil
+func handleErr(err error, descriptor string) {
+    if err != nil {
+        fmt.Println(descriptor, err)
+        return
+    }
+}
+
+func getEmailSlice(fullName string) string {
+    startIndex := strings.Index(fullName, "<")
+    endIndex := strings.Index(fullName, ">")
+    runes := []rune(fullName)
+    return string(runes[startIndex+1:endIndex])
+}


### PR DESCRIPTION
### Summary
Currently we maintain multiple changelogs in ecs-init manually.  The release process makes updating the changelogs inconsistent. 
I'm seeking to make the process automatic. 
This creates a core changelog in the CHANGE_TEMPLATE file with all required details for each of the different changelog formats: amazon-linux/debian/markdown.
For each release, the engineer will update the CHANGE_TEMPLATE then will execute the changelog.go file (`go build changelog.go && ./changelog`)
Running the included script will update all the changelogs in place with the relevant contents of the CHANGE_TEMPLATE.

NOTE: All included new changelogs have been generated by the script.

### Implementation details
Each or the entries in the CHANGE_TEMPLATE is parsed into a `Change` object.  An array of these change objects is passed to each of the formatters to generate a new changelog string.  Finally, the changelog files are overwritten with these updated changelog strings.

### Testing
I used the script and `git diff` to build toward a minimal diff between the current changelogs and the generated changelogs.  Tested manually to generate all changelogs.

I also successfully ran `make rpm` from an AL2 ecs-optimized instance using the generated changelog for amazon-linux.

### Description for the changelog
Add script to generate changelogs from a central file

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
