### PR TITLE
volume plugin capability for EFS and unit tests

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -222,7 +222,7 @@ func (c *Client) GetContainerLogTail(logWindowSize string) string {
 	containerToLog, _ := c.findAgentContainer()
 	if containerToLog == "" {
 		log.Info("No existing container to take logs from.")
-                return ""
+		return ""
 	}
 	// we want to capture some logs from our removed containers in case of failure
 	var containerLogBuf bytes.Buffer
@@ -253,6 +253,7 @@ func (c *Client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 		"ECS_ENABLE_TASK_IAM_ROLE":              "true",
 		"ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST": "true",
 		"ECS_AGENT_LABELS":                      "",
+		"ECS_VOLUME_PLUGIN_CAPABILITIES":        `["efsAuth"]`,
 	}
 
 	// for al, al2 add host ssl cert directory envvar if available

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -233,7 +233,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey("ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true", envVariables, t)
 	expectKey("ECS_ENABLE_TASK_ENI=true", envVariables, t)
 	expectKey("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true", envVariables, t)
-
+	expectKey(`ECS_VOLUME_PLUGIN_CAPABILITIES=["efsAuth"]`, envVariables, t)
 	if cfg.Image != config.AgentImageName {
 		t.Errorf("Expected image to be %s", config.AgentImageName)
 	}

--- a/ecs-init/volumes/ecs_volume_driver.go
+++ b/ecs-init/volumes/ecs_volume_driver.go
@@ -15,7 +15,6 @@ package volumes
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 
 	"github.com/cihub/seelog"
@@ -80,9 +79,6 @@ func setOptions(options map[string]string) *MountHelper {
 		switch k {
 		case "type":
 			mnt.MountType = v
-		case "netns":
-			pid, _ := strconv.Atoi(v)
-			mnt.NetNSPid = pid
 		case "o":
 			mnt.Options = v
 		case "device":

--- a/ecs-init/volumes/efs_mount_helper.go
+++ b/ecs-init/volumes/efs_mount_helper.go
@@ -32,7 +32,6 @@ type MountHelper struct {
 	Device    string
 	Target    string
 	Options   string
-	NetNSPid  int
 }
 
 // Mount helps mount EFS volumes

--- a/ecs-init/volumes/efs_mount_helper_test.go
+++ b/ecs-init/volumes/efs_mount_helper_test.go
@@ -1,0 +1,108 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package volumes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEFSMount(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	runMount = func([]string) error {
+		return nil
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.NoError(t, m.Mount())
+}
+
+func TestEFSMountFailure(t *testing.T) {
+	m := MountHelper{
+		Device: "xyz",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	runMount = func([]string) error {
+		return errors.New("mount failure")
+	}
+	defer func() {
+		runMount = runMountCommand
+	}()
+	assert.Error(t, m.Mount())
+}
+
+func TestEFSOptionsValidate(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+	}
+	assert.Error(t, m.Validate(), "missing target field")
+}
+
+func TestEFSUnmount(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "/mount", nil
+	}
+	runUnmount = func(path string, target string) error {
+		assert.Equal(t, "/mount", path)
+		assert.Equal(t, "/var/lib/ecs/volumes/123", target)
+		return nil
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.NoError(t, m.Unmount())
+}
+
+func TestEFSNoUnmountBinary(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "", errors.New("unmount not found")
+	}
+	defer func() {
+		lookPath = getPath
+	}()
+	assert.Error(t, m.Unmount())
+}
+
+func TestEFSUnmountError(t *testing.T) {
+	m := MountHelper{
+		Device: "fs-123",
+		Target: "/var/lib/ecs/volumes/123",
+	}
+	lookPath = func(string) (string, error) {
+		return "/mount", nil
+	}
+	runUnmount = func(path string, target string) error {
+		return errors.New("unmount failure")
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.Error(t, m.Unmount())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This env var will be used by agent to send capability for EFS support by ECS Volume Plugin. 
Using the capability "efsAuth" and not "efs", since preview already supports "efs" capability , so to differentiate from that, we are using the "efsAuth" as the value. 

Added unit tests for efs_mount_helper.go , now that netns and creds uri options are finalized. 

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
