### PR TITLE
handle state file corruption gracefully

### DIFF
--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/cihub/seelog"
 )
 
 const (
@@ -143,6 +145,7 @@ func (s *StateManager) load(a interface{}) error {
 	}
 	err = json.Unmarshal(b, a)
 	if err != nil {
+		seelog.Criticalf("Could not unmarshal existing state; corrupted data: %v. Please remove statefile at %s", err, PluginStateFileAbsPath)
 		return err
 	}
 	return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Empty state files cannot be unmarshaled. 
Log that in volume plugin logs. 

testing: 
```
level=info time=2020-01-29T22:02:03Z msg="Loading plugin state information"
level=critical time=2020-01-29T22:02:03Z msg="Could not unmarshal existing state; corrupted data: unexpected end of JSON input. Please remove statefile at /var/lib/ecs/data/ecs_volume_plugin.json"
```

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
