### PR TITLE
make mount/unmount commands return error string

### DIFF
--- a/ecs-init/volumes/efs_mount_helper.go
+++ b/ecs-init/volumes/efs_mount_helper.go
@@ -14,6 +14,8 @@
 package volumes
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -54,7 +56,7 @@ var runMount = runMountCommand
 
 func runMountCommand(args []string) error {
 	mountcmd := exec.Command(MountBinary, args...)
-	return mountcmd.Run()
+	return runCmd(mountcmd)
 }
 
 // Validate validates fields as part of the mount command
@@ -91,5 +93,17 @@ var runUnmount = runUnmountCommand
 
 func runUnmountCommand(path string, target string) error {
 	umountCmd := exec.Command(path, target)
-	return umountCmd.Run()
+	return runCmd(umountCmd)
+}
+
+var runCmd = runCommand
+
+func runCommand(cmd *exec.Cmd) error {
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return err
+	}
+	return errors.New(stderr.String())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Before the changes:
```
$ docker volume create --name efsvolume0  -d amazon-ecs-volume-plugin --opt o=tls,ro --opt type=efs --opt device=fs-3200b698
Error response from daemon: create efsvolume0: VolumeDriver.Create: mounting volume failed: exit status 32
```

After the changes:
```
$ docker volume create --name efsvolume0  -d amazon-ecs-volume-plugin --opt o=tls,ro --opt type=efs --opt device=fs-3200b698
Error response from daemon: create efsvolume0: VolumeDriver.Create: mounting volume failed: mount.nfs4: Connection reset by peer
```



### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
