### PR TITLE
Fix ECS_UPDATE_DOWNLOAD_DIR functionality

### DIFF
--- a/ecs-init/cache/cache.go
+++ b/ecs-init/cache/cache.go
@@ -318,6 +318,6 @@ func (d *Downloader) getDesiredImageFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	desiredImageFile := strings.TrimSpace(config.CacheDirectory() + "/" + d.fs.Base(desiredImageString))
+	desiredImageFile := strings.TrimSpace(config.UpdateDownloadDir() + "/" + d.fs.Base(desiredImageString))
 	return desiredImageFile, nil
 }

--- a/ecs-init/cache/cache_test.go
+++ b/ecs-init/cache/cache_test.go
@@ -479,3 +479,25 @@ func TestLoadDesiredAgent(t *testing.T) {
 
 	d.LoadDesiredAgent()
 }
+
+func TestLoadDesiredAgent_WithUpdateDownloadDirEnvVar(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	os.Setenv("ECS_UPDATE_DOWNLOAD_DIR", "/tmp")
+	defer os.Unsetenv("ECS_UPDATE_DOWNLOAD_DIR")
+
+	desiredImage := "my-new-agent-image"
+
+	mockFS := NewMockfileSystem(mockCtrl)
+
+	mockFS.EXPECT().Open(config.DesiredImageLocatorFile()).Return(ioutil.NopCloser(bytes.NewBufferString(desiredImage+"\n")), nil)
+	mockFS.EXPECT().Base(gomock.Any()).Return(desiredImage + "\n")
+	mockFS.EXPECT().Open("/tmp/" + desiredImage)
+
+	d := &Downloader{
+		fs: mockFS,
+	}
+
+	d.LoadDesiredAgent()
+}

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -135,6 +135,14 @@ func CacheDirectory() string {
 	return directoryPrefix + "/var/cache/ecs"
 }
 
+// UpdateDownloadDir returns to location of the agent update download dir
+func UpdateDownloadDir() string {
+	if downloadDir := os.Getenv("ECS_UPDATE_DOWNLOAD_DIR"); downloadDir != "" {
+		return downloadDir
+	}
+	return CacheDirectory()
+}
+
 // CacheState returns the location on disk where cache state is stored
 func CacheState() string {
 	return CacheDirectory() + "/state"
@@ -165,7 +173,7 @@ func AgentRemoteTarballMD5Key() (string, error) {
 
 // DesiredImageLocatorFile returns the location on disk of a well-known file describing an Agent image to load
 func DesiredImageLocatorFile() string {
-	return CacheDirectory() + "/desired-image"
+	return UpdateDownloadDir() + "/desired-image"
 }
 
 // DockerUnixSocket returns the docker socket endpoint and whether it's read from DockerHostEnvVar

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDockerUnixSocketWithoutDockerHost(t *testing.T) {
@@ -203,4 +205,26 @@ func TestAgentPrivilegedNotConfigured(t *testing.T) {
 			t.Errorf("Agent was expected to be running without privileged mode. Testcase (%s)", test)
 		}
 	}
+}
+
+func TestUpdateDownloadDir_WithEnvVar(t *testing.T) {
+	os.Setenv("ECS_UPDATE_DOWNLOAD_DIR", "/tmp")
+	defer os.Unsetenv("ECS_UPDATE_DOWNLOAD_DIR")
+
+	require.Equal(t, "/tmp", UpdateDownloadDir())
+}
+
+func TestUpdateDownloadDir_NoEnvVar(t *testing.T) {
+	require.Equal(t, "/var/cache/ecs", UpdateDownloadDir())
+}
+
+func TestDesiredImageLocatorFile_WithEnvVar(t *testing.T) {
+	os.Setenv("ECS_UPDATE_DOWNLOAD_DIR", "/foo")
+	defer os.Unsetenv("ECS_UPDATE_DOWNLOAD_DIR")
+
+	require.Equal(t, "/foo/desired-image", DesiredImageLocatorFile())
+}
+
+func TestDesiredImageLocatorFile_NoEnvVar(t *testing.T) {
+	require.Equal(t, "/var/cache/ecs/desired-image", DesiredImageLocatorFile())
 }

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -225,7 +225,7 @@ func (c *Client) GetContainerLogTail(logWindowSize string) string {
 	containerToLog, _ := c.findAgentContainer()
 	if containerToLog == "" {
 		log.Info("No existing container to take logs from.")
-                return ""
+		return ""
 	}
 	// we want to capture some logs from our removed containers in case of failure
 	var containerLogBuf bytes.Buffer
@@ -370,6 +370,10 @@ func (c *Client) getHostConfig(envVarsFromFiles map[string]string) *godocker.Hos
 		config.CgroupMountpoint() + ":" + DefaultCgroupMountpoint,
 		// bind mount instance config dir
 		config.InstanceConfigDirectory() + ":" + config.InstanceConfigDirectory(),
+	}
+	// only add update download dir if it is not the cache directory (the default setting)
+	if config.UpdateDownloadDir() != config.CacheDirectory() {
+		binds = append(binds, config.UpdateDownloadDir()+":"+config.UpdateDownloadDir())
 	}
 
 	// for al, al2 add host ssl cert directory mounts

--- a/ecs-init/engine/engine.go
+++ b/ecs-init/engine/engine.go
@@ -197,7 +197,7 @@ func (e *Engine) StartSupervised() error {
 		case upgradeAgentExitCode:
 			err = e.upgradeAgent()
 			if err != nil {
-				log.Error("could not upgrade agent", err)
+				log.Error("could not upgrade agent: ", err)
 			} else {
 				// continuing here because a successful upgrade doesn't need to backoff retries
 				continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Customers can use ECS_UPDATE_DOWNLOAD_DIR to tell the agent to download
updates to a custom directory, rather than the agent cache directory at
/var/cache/ecs. In order for the upgrade to take place, ecs-init also
needs access to this directory and needs to know about it by reading the
environment variable.


### Testing

An upgrade using the default value (/var/cache/ecs) and setting a custom value set using ECS_UPDATE_DOWNLOAD_DIR  was tested manually. New unit tests have also been added.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

Fix ECS_UPDATE_DOWNLOAD_DIR functionality

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
