### PR TITLE
docker: add '/etc/alternatives' to mounts

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -94,6 +94,10 @@ const (
 	// iptablesExecutableHostDir specifies the location of the iptable
 	// executable inside container.
 	iptablesExecutableContainerDir = "/host/sbin"
+	// iptablesAltDir specifies the location of iptables alternatives
+	iptablesAltDir = "/etc/alternatives"
+	// legacyDir holds the location of legacy iptables
+	iptablesLegacyDir = "/usr/sbin"
 
 	// the following libDirs  specify the location of shared libraries on the
 	// host and in the Agent container required for the execution of the iptables
@@ -225,7 +229,7 @@ func (c *Client) GetContainerLogTail(logWindowSize string) string {
 	containerToLog, _ := c.findAgentContainer()
 	if containerToLog == "" {
 		log.Info("No existing container to take logs from.")
-                return ""
+		return ""
 	}
 	// we want to capture some logs from our removed containers in case of failure
 	var containerLogBuf bytes.Buffer

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -29,8 +29,8 @@ import (
 // Note: Change this value every time when a new bind mount is added to
 // agent for the tests to pass
 const (
-	expectedAgentBindsUnspecifiedPlatform = 17
-	expectedAgentBindsSuseUbuntuPlatform  = 15
+	expectedAgentBindsUnspecifiedPlatform = 19
+	expectedAgentBindsSuseUbuntuPlatform  = 17
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -267,6 +267,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+":ro", binds, t)
 	expectKey(iptablesLib64Dir+":"+iptablesLib64Dir+":ro", binds, t)
 	expectKey(iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+":ro", binds, t)
+	expectKey(iptablesAltDir+":"+iptablesAltDir+":ro", binds, t)
+	expectKey(iptablesLegacyDir+":"+iptablesLegacyDir+":ro", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)
 	}

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -40,6 +40,8 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+readOnly,
 		iptablesLib64Dir+":"+iptablesLib64Dir+readOnly,
 		iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+readOnly,
+		iptablesAltDir+":"+iptablesAltDir+readOnly,
+		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
 	)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

In some circumstances, /sbin/iptables may be a symlink to a binary in
/etc/alternatives. In order to handle this case, its imperative that
agent is also able to access the /etc/alternatives folder.

### Implementation details
<!-- How are the changes implemented?



If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
We now mount in "/etc/alternatives" so that binaries within that directory are callable by agent.

### Testing
<!-- How was this tested? -->

**Testing is still WIP**

1. i build an rpm using `make rpm`
2. I installed it on an AL2 AMI
3. I've validated that the following appears upon docker inspect:

```
            "Binds": [
                "/var/run:/var/run",
                "/var/log/ecs:/log",
                "/var/lib/ecs/data:/data",
                "/etc/ecs:/etc/ecs",
                "/var/cache/ecs:/var/cache/ecs",
                "/sys/fs/cgroup:/sys/fs/cgroup",
                "/var/lib/ecs:/var/lib/ecs",
                "/etc/pki:/etc/pki:ro",
                "/run/docker/plugins:/run/docker/plugins:ro",
                "/etc/docker/plugins:/etc/docker/plugins:ro",
                "/usr/lib/docker/plugins:/usr/lib/docker/plugins:ro",
                "/proc:/host/proc:ro",
                "/usr/lib:/usr/lib:ro",
                "/lib:/lib:ro",
                "/usr/lib64:/usr/lib64:ro",
                "/lib64:/lib64:ro",
                "/sbin:/host/sbin:ro",
                "/etc/alternatives:/etc/alternatives:ro",
                "/usr/sbin:/usr/sbin:ro"
            ],


```


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:

-->

Bug - Fix agent's use of iptables when installed as an alternative



### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
