### PR TITLE
Changed changelog timestamp output to UTC

### DIFF
--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -255,7 +255,7 @@ fi
 %endif
 
 %changelog
-* Fri Feb 21 2020 Jessie Young <youngli@amazon.com> - 1.37.0-2
+* Sat Feb 22 2020 Jessie Young <youngli@amazon.com> - 1.37.0-2
 - Cache Agent version 1.37.0
 - Add '/etc/alternatives' to mounts
 
@@ -320,7 +320,7 @@ fi
 * Thu Jan 31 2019 Shaobo Han <obo@amazon.com> - 1.25.2-1
 - Cache Agent version 1.25.2
 
-* Fri Jan 25 2019 Adnan Khan <adnkha@amazon.com> - 1.25.1-1
+* Sat Jan 26 2019 Adnan Khan <adnkha@amazon.com> - 1.25.1-1
 - Cache Agent version 1.25.1
 - Update ecr models for private link support
 
@@ -346,13 +346,13 @@ fi
 - Support configurable logconfig for Agent container to reduce disk usage
 - ECS Agent will use the host's cert store on the Amazon Linux platform
 
-* Thu Sep 13 2018 Yumeng Xie <yumex@amazon.com> - 1.20.3-1
+* Fri Sep 14 2018 Yumeng Xie <yumex@amazon.com> - 1.20.3-1
 - Cache Agent version 1.20.3
 
-* Thu Aug 30 2018 Feng Xiong <fenxiong@amazon.com> - 1.20.2-1
+* Fri Aug 31 2018 Feng Xiong <fenxiong@amazon.com> - 1.20.2-1
 - Cache Agent version 1.20.2
 
-* Wed Aug 08 2018 Peng Yin <penyin@amazon.com> - 1.20.1-1
+* Thu Aug 09 2018 Peng Yin <penyin@amazon.com> - 1.20.1-1
 - Cache Agent version 1.20.1
 
 * Wed Aug 01 2018 Haikuo Liu <haikuo@amazon.com> - 1.20.0-1
@@ -399,16 +399,16 @@ fi
 * Tue Nov 21 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.16.0-1
 - Cache Agent version 1.16.0
 
-* Tue Nov 14 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.15.2-1
+* Wed Nov 15 2017 Noah Meyerhans <nmeyerha@amazon.com> - 1.15.2-1
 - Cache Agent version 1.15.2
 
 * Tue Oct 17 2017 Jacob Vallejo <jakeev@amazon.com> - 1.15.1-1
 - Update ECS Agent version
 
-* Fri Oct 06 2017 Justin Haynes <jushay@amazon.com> - 1.15.0-1
+* Sat Oct 07 2017 Justin Haynes <jushay@amazon.com> - 1.15.0-1
 - Update ECS Agent version
 
-* Fri Sep 29 2017 Justin Haynes <jushay@amazon.com> - 1.14.5-1
+* Sat Sep 30 2017 Justin Haynes <jushay@amazon.com> - 1.14.5-1
 - Update ECS Agent version
 
 * Tue Aug 22 2017 Justin Haynes <jushay@amazon.com> - 1.14.4-1

--- a/packaging/suse/amazon-ecs-init.changes
+++ b/packaging/suse/amazon-ecs-init.changes
@@ -1,151 +1,151 @@
 -------------------------------------------------------------------
-Fri Feb 21, 17:40:00 PST 2020 - youngli@amazon.com - 1.37.0-2
+Sat Feb 22, 01:40:00 UTC 2020 - youngli@amazon.com - 1.37.0-2
 
 - Cache Agent version 1.37.0
 - Add '/etc/alternatives' to mounts
 -------------------------------------------------------------------
-Tue Feb 04, 14:32:00 PST 2020 - fierlion@amazon.com - 1.36.2-1
+Tue Feb 04, 22:32:00 UTC 2020 - fierlion@amazon.com - 1.36.2-1
 
 - Cache Agent version 1.36.2
 - update sbin mount point to avoid conflict with Docker >= 19.03.5
 -------------------------------------------------------------------
-Fri Jan 10, 11:00:00 PST 2020 - yhlee@amazon.com - 1.36.1-1
+Fri Jan 10, 19:00:00 UTC 2020 - yhlee@amazon.com - 1.36.1-1
 
 - Cache Agent version 1.36.1
 -------------------------------------------------------------------
-Wed Jan 08, 11:00:00 PST 2020 - cssparr@amazon.com - 1.36.0-1
+Wed Jan 08, 19:00:00 UTC 2020 - cssparr@amazon.com - 1.36.0-1
 
 - Cache Agent version 1.36.0
 - capture a fixed tail of container logs when removing a container
 -------------------------------------------------------------------
-Thu Dec 12, 09:00:00 PST 2019 - petderek@amazon.com - 1.35.0-1
+Thu Dec 12, 17:00:00 UTC 2019 - petderek@amazon.com - 1.35.0-1
 
 - Cache Agent version 1.35.0
 - Fix bug where stopping agent gracefully would still restart ecs-init
 -------------------------------------------------------------------
-Mon Nov 11, 09:00:00 PST 2019 - shugy@amazon.com - 1.33.0-1
+Mon Nov 11, 17:00:00 UTC 2019 - shugy@amazon.com - 1.33.0-1
 
 - Cache Agent version 1.33.0
 - Fix destination path in docker socket bind mount to match the one specified using DOCKER_HOST on Amazon Linux 2
 -------------------------------------------------------------------
-Mon Oct 28, 09:00:00 PST 2019 - shugy@amazon.com - 1.32.1-1
+Mon Oct 28, 17:00:00 UTC 2019 - shugy@amazon.com - 1.32.1-1
 
 - Cache Agent version 1.32.1
 - Add the ability to set Agent container's labels
 -------------------------------------------------------------------
-Wed Sep 25, 10:00:00 PST 2019 - cssparr@amazon.com - 1.32.0-1
+Wed Sep 25, 18:00:00 UTC 2019 - cssparr@amazon.com - 1.32.0-1
 
 - Cache Agent version 1.32.0
 -------------------------------------------------------------------
-Fri Sep 13, 10:00:00 PST 2019 - cya@amazon.com - 1.31.0-1
+Fri Sep 13, 18:00:00 UTC 2019 - cya@amazon.com - 1.31.0-1
 
 - Cache Agent version 1.31.0
 -------------------------------------------------------------------
-Thu Aug 15, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.30.0-1
+Thu Aug 15, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.30.0-1
 
 - Cache Agent version 1.30.0
 -------------------------------------------------------------------
-Mon Jul 08, 11:06:00 PST 2019 - shugy@amazon.com - 1.29.1-1
+Mon Jul 08, 19:06:00 UTC 2019 - shugy@amazon.com - 1.29.1-1
 
 - Cache Agent version 1.29.1
 -------------------------------------------------------------------
-Thu Jun 06, 14:47:00 PST 2019 - yumex@amazon.com - 1.29.0-1
+Thu Jun 06, 22:47:00 UTC 2019 - yumex@amazon.com - 1.29.0-1
 
 - Cache Agent version 1.29.0
 -------------------------------------------------------------------
-Fri May 31, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.28.1-2
+Fri May 31, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.28.1-2
 
 - Cache Agent version 1.28.1
 - Use exponential backoff when restarting agent
 -------------------------------------------------------------------
-Thu May 09, 10:00:00 PST 2019 - fenxiong@amazon.com - 1.28.0-1
+Thu May 09, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.28.0-1
 
 - Cache Agent version 1.28.0
 -------------------------------------------------------------------
-Thu Mar 28, 14:00:00 PST 2019 - obo@amazon.com - 1.27.0-1
+Thu Mar 28, 22:00:00 UTC 2019 - obo@amazon.com - 1.27.0-1
 
 - Cache Agent version 1.27.0
 -------------------------------------------------------------------
-Thu Mar 21, 13:30:00 PST 2019 - petderek@amazon.com - 1.26.1-1
+Thu Mar 21, 21:30:00 UTC 2019 - petderek@amazon.com - 1.26.1-1
 
 - Cache Agent version 1.26.1
 -------------------------------------------------------------------
-Thu Feb 28, 13:30:00 PST 2019 - petderek@amazon.com - 1.26.0-1
+Thu Feb 28, 21:30:00 UTC 2019 - petderek@amazon.com - 1.26.0-1
 
 - Cache Agent version 1.26.0
 - Add support for running iptables within agent container
 -------------------------------------------------------------------
-Fri Feb 15, 11:30:00 PST 2019 - fierlion@amazon.com - 1.25.3-1
+Fri Feb 15, 19:30:00 UTC 2019 - fierlion@amazon.com - 1.25.3-1
 
 - Cache Agent version 1.25.3
 -------------------------------------------------------------------
-Thu Jan 31, 11:53:00 PST 2019 - obo@amazon.com - 1.25.2-1
+Thu Jan 31, 19:53:00 UTC 2019 - obo@amazon.com - 1.25.2-1
 
 - Cache Agent version 1.25.2
 -------------------------------------------------------------------
-Fri Jan 25, 20:39:00 PST 2019 - adnkha@amazon.com - 1.25.1-1
+Sat Jan 26, 04:39:00 UTC 2019 - adnkha@amazon.com - 1.25.1-1
 
 - Cache Agent version 1.25.1
 - Update ecr models for private link support
 -------------------------------------------------------------------
-Thu Jan 17, 10:32:18 PST 2019 - yuzhusun@amazon.com - 1.25.0-1
+Thu Jan 17, 18:32:18 UTC 2019 - yuzhusun@amazon.com - 1.25.0-1
 
 - Cache Agent version 1.25.0
 - Add Nvidia GPU support for p2 and p3 instances
 -------------------------------------------------------------------
-Fri Jan 04, 10:16:18 PST 2019 - yuzhusun@amazon.com - 1.24.0-1
+Fri Jan 04, 18:16:18 UTC 2019 - yuzhusun@amazon.com - 1.24.0-1
 
 - Cache Agent version 1.24.0
 -------------------------------------------------------------------
-Fri Nov 16, 11:00:00 PST 2018 - jakeev@amazon.com - 1.22.0-4
+Fri Nov 16, 19:00:00 UTC 2018 - jakeev@amazon.com - 1.22.0-4
 
 - Cache ECS agent version 1.22.0 for x86_64 & ARM
 - Support ARM architecture builds
 -------------------------------------------------------------------
-Thu Nov 15, 11:00:00 PST 2018 - jakeev@amazon.com - 1.22.0-3
+Thu Nov 15, 19:00:00 UTC 2018 - jakeev@amazon.com - 1.22.0-3
 
 - Rebuild
 -------------------------------------------------------------------
-Fri Nov 02, 09:51:28 PST 2018 - yhlee@amazon.com - 1.22.0-2
+Fri Nov 02, 17:51:28 UTC 2018 - yhlee@amazon.com - 1.22.0-2
 
 - Cache Agent version 1.22.0
 -------------------------------------------------------------------
-Thu Oct 11, 10:49:28 PST 2018 - sharanyd@amazon.com - 1.21.0-1
+Thu Oct 11, 18:49:28 UTC 2018 - sharanyd@amazon.com - 1.21.0-1
 
 - Cache Agent version 1.21.0
 - Support configurable logconfig for Agent container to reduce disk usage
 - ECS Agent will use the host's cert store on the Amazon Linux platform
 -------------------------------------------------------------------
-Thu Sep 13, 16:38:10 PST 2018 - yumex@amazon.com - 1.20.3-1
+Fri Sep 14, 00:38:10 UTC 2018 - yumex@amazon.com - 1.20.3-1
 
 - Cache Agent version 1.20.3
 -------------------------------------------------------------------
-Thu Aug 30, 16:43:01 PST 2018 - fenxiong@amazon.com - 1.20.2-1
+Fri Aug 31, 00:43:01 UTC 2018 - fenxiong@amazon.com - 1.20.2-1
 
 - Cache Agent version 1.20.2
 -------------------------------------------------------------------
-Wed Aug 08, 16:04:01 PST 2018 - penyin@amazon.com - 1.20.1-1
+Thu Aug 09, 00:04:01 UTC 2018 - penyin@amazon.com - 1.20.1-1
 
 - Cache Agent version 1.20.1
 -------------------------------------------------------------------
-Wed Aug 01, 15:44:01 PST 2018 - haikuo@amazon.com - 1.20.0-1
+Wed Aug 01, 23:44:01 UTC 2018 - haikuo@amazon.com - 1.20.0-1
 
 - Cache Agent version 1.20.0
 -------------------------------------------------------------------
-Thu Jul 26, 13:31:24 PST 2018 - haikuo@amazon.com - 1.19.1-1
+Thu Jul 26, 21:31:24 UTC 2018 - haikuo@amazon.com - 1.19.1-1
 
 - Cache Agent version 1.19.1
 -------------------------------------------------------------------
-Thu Jul 19, 15:09:41 PST 2018 - fenxiong@amazon.com - 1.19.0-1
+Thu Jul 19, 23:09:41 UTC 2018 - fenxiong@amazon.com - 1.19.0-1
 
 - Cache Agent version 1.19.0
 -------------------------------------------------------------------
-Wed May 23, 11:00:00 PST 2018 - iweller@amazon.com - 1.18.0-2
+Wed May 23, 19:00:00 UTC 2018 - iweller@amazon.com - 1.18.0-2
 
 - Spec file cleanups
 - Enable builds for both AL1 and AL2
 -------------------------------------------------------------------
-Fri May 04, 13:30:22 PST 2018 - haikuo@amazon.com - 1.18.0-1
+Fri May 04, 21:30:22 UTC 2018 - haikuo@amazon.com - 1.18.0-1
 
 - Cache Agent version 1.18.0
 - Add support for regional buckets
@@ -153,105 +153,105 @@ Fri May 04, 13:30:22 PST 2018 - haikuo@amazon.com - 1.18.0-1
 - Download agent based on the partition
 - Mount Docker plugin files dir
 -------------------------------------------------------------------
-Fri Mar 30, 12:20:41 PST 2018 - jushay@amazon.com - 1.17.3-1
+Fri Mar 30, 20:20:41 UTC 2018 - jushay@amazon.com - 1.17.3-1
 
 - Cache Agent version 1.17.3
 - Use s3client instead of httpclient when downloading
 -------------------------------------------------------------------
-Mon Mar 05, 10:31:19 PST 2018 - jakeev@amazon.com - 1.17.2-1
+Mon Mar 05, 18:31:19 UTC 2018 - jakeev@amazon.com - 1.17.2-1
 
 - Cache Agent version 1.17.2
 -------------------------------------------------------------------
-Mon Feb 19, 10:57:33 PST 2018 - jushay@amazon.com - 1.17.1-1
+Mon Feb 19, 18:57:33 UTC 2018 - jushay@amazon.com - 1.17.1-1
 
 - Cache Agent version 1.17.1
 -------------------------------------------------------------------
-Mon Feb 05, 10:03:33 PST 2018 - jushay@amazon.com - 1.17.0-2
+Mon Feb 05, 18:03:33 UTC 2018 - jushay@amazon.com - 1.17.0-2
 
 - Cache Agent version 1.17.0
 -------------------------------------------------------------------
-Tue Jan 16, 10:12:56 PST 2018 - petderek@amazon.com - 1.16.2-1
+Tue Jan 16, 18:12:56 UTC 2018 - petderek@amazon.com - 1.16.2-1
 
 - Cache Agent version 1.16.2
 - Add GovCloud endpoint
 -------------------------------------------------------------------
-Wed Jan 03, 14:52:56 PST 2018 - nmeyerha@amazon.com - 1.16.1-1
+Wed Jan 03, 22:52:56 UTC 2018 - nmeyerha@amazon.com - 1.16.1-1
 
 - Cache Agent version 1.16.1
 - Improve startup behavior when Docker socket doesn't exist yet
 -------------------------------------------------------------------
-Tue Nov 21, 13:03:59 PST 2017 - nmeyerha@amazon.com - 1.16.0-1
+Tue Nov 21, 21:03:59 UTC 2017 - nmeyerha@amazon.com - 1.16.0-1
 
 - Cache Agent version 1.16.0
 -------------------------------------------------------------------
-Tue Nov 14, 16:53:54 PST 2017 - nmeyerha@amazon.com - 1.15.2-1
+Wed Nov 15, 00:53:54 UTC 2017 - nmeyerha@amazon.com - 1.15.2-1
 
 - Cache Agent version 1.15.2
 -------------------------------------------------------------------
-Tue Oct 17, 07:55:19 PST 2017 - jakeev@amazon.com - 1.15.1-1
+Tue Oct 17, 15:55:19 UTC 2017 - jakeev@amazon.com - 1.15.1-1
 
 - Update ECS Agent version
 -------------------------------------------------------------------
-Fri Oct 06, 23:50:23 PST 2017 - jushay@amazon.com - 1.15.0-1
+Sat Oct 07, 07:50:23 UTC 2017 - jushay@amazon.com - 1.15.0-1
 
 - Update ECS Agent version
 -------------------------------------------------------------------
-Fri Sep 29, 17:36:34 PST 2017 - jushay@amazon.com - 1.14.5-1
+Sat Sep 30, 01:36:34 UTC 2017 - jushay@amazon.com - 1.14.5-1
 
 - Update ECS Agent version
 -------------------------------------------------------------------
-Tue Aug 22, 15:44:03 PST 2017 - jushay@amazon.com - 1.14.4-1
+Tue Aug 22, 23:44:03 UTC 2017 - jushay@amazon.com - 1.14.4-1
 
 - Update ECS Agent version
 -------------------------------------------------------------------
-Thu Jun 01, 11:00:00 PST 2017 - adnkha@amazon.com - 1.14.2-2
+Thu Jun 01, 19:00:00 UTC 2017 - adnkha@amazon.com - 1.14.2-2
 
 - Cache Agent version 1.14.2
 - Add functionality for running agent with userns=host when Docker has userns-remap enabled
 - Add support for Docker 17.03.1ce
 -------------------------------------------------------------------
-Mon Mar 06, 11:00:00 PST 2017 - adnkha@amazon.com - 1.14.1-1
+Mon Mar 06, 19:00:00 UTC 2017 - adnkha@amazon.com - 1.14.1-1
 
 - Cache Agent version 1.14.1
 -------------------------------------------------------------------
-Wed Jan 25, 11:00:00 PST 2017 - aithal@amazon.com - 1.14.0-2
+Wed Jan 25, 19:00:00 UTC 2017 - aithal@amazon.com - 1.14.0-2
 
 - Add retry-backoff for pinging the Docker socket when creating the Docker client
 -------------------------------------------------------------------
-Mon Jan 16, 11:00:00 PST 2017 - petderek@amazon.com - 1.14.0-1
+Mon Jan 16, 19:00:00 UTC 2017 - petderek@amazon.com - 1.14.0-1
 
 - Cache Agent version 1.14.0
 -------------------------------------------------------------------
-Fri Jan 06, 11:00:00 PST 2017 - nmeyerha@amazon.com - 1.13.1-2
+Fri Jan 06, 19:00:00 UTC 2017 - nmeyerha@amazon.com - 1.13.1-2
 
 - Update Requires to indicate support for docker <= 1.12.6
 -------------------------------------------------------------------
-Mon Nov 14, 11:00:00 PST 2016 - penyin@amazon.com - 1.13.1-1
+Mon Nov 14, 19:00:00 UTC 2016 - penyin@amazon.com - 1.13.1-1
 
 - Cache Agent version 1.13.1
 -------------------------------------------------------------------
-Tue Sep 27, 11:00:00 PST 2016 - nmeyerha@amazon.com - 1.13.0-1
+Tue Sep 27, 19:00:00 UTC 2016 - nmeyerha@amazon.com - 1.13.0-1
 
 - Cache Agent version 1.13.0
 -------------------------------------------------------------------
-Tue Sep 13, 11:00:00 PST 2016 - aithal@amazon.com - 1.12.2-1
+Tue Sep 13, 19:00:00 UTC 2016 - aithal@amazon.com - 1.12.2-1
 
 - Cache Agent version 1.12.2
 -------------------------------------------------------------------
-Wed Aug 17, 11:00:00 PST 2016 - penyin@amazon.com - 1.12.1-1
+Wed Aug 17, 19:00:00 UTC 2016 - penyin@amazon.com - 1.12.1-1
 
 - Cache Agent version 1.12.1
 -------------------------------------------------------------------
-Wed Aug 10, 11:00:00 PST 2016 - aithal@amazon.com - 1.12.0-1
+Wed Aug 10, 19:00:00 UTC 2016 - aithal@amazon.com - 1.12.0-1
 
 - Cache Agent version 1.12.0
 - Add netfilter rules to support host network reaching credentials proxy
 -------------------------------------------------------------------
-Wed Aug 03, 11:00:00 PST 2016 - skarp@amazon.com - 1.11.1-1
+Wed Aug 03, 19:00:00 UTC 2016 - skarp@amazon.com - 1.11.1-1
 
 - Cache Agent version 1.11.1
 -------------------------------------------------------------------
-Tue Jul 05, 11:00:00 PST 2016 - skarp@amazon.com - 1.11.0-1
+Tue Jul 05, 19:00:00 UTC 2016 - skarp@amazon.com - 1.11.0-1
 
 - Cache Agent version 1.11.0
 - Add support for Docker 1.11.2
@@ -259,114 +259,114 @@ Tue Jul 05, 11:00:00 PST 2016 - skarp@amazon.com - 1.11.0-1
 - Eliminate requirement that /tmp and /var/cache be on the same filesystem
 - Start agent with host network mode
 -------------------------------------------------------------------
-Mon May 23, 11:00:00 PST 2016 - penyin@amazon.com - 1.10.0-1
+Mon May 23, 19:00:00 UTC 2016 - penyin@amazon.com - 1.10.0-1
 
 - Cache Agent version 1.10.0
 - Add support for Docker 1.11.1
 -------------------------------------------------------------------
-Tue Apr 26, 11:00:00 PST 2016 - penyin@amazon.com - 1.9.0-1
+Tue Apr 26, 19:00:00 UTC 2016 - penyin@amazon.com - 1.9.0-1
 
 - Cache Agent version 1.9.0
 - Make awslogs driver available by default
 -------------------------------------------------------------------
-Thu Mar 24, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.2-1
+Thu Mar 24, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.2-1
 
 - Cache Agent version 1.8.2
 -------------------------------------------------------------------
-Mon Feb 29, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.1-1
+Mon Feb 29, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.1-1
 
 - Cache Agent version 1.8.1
 -------------------------------------------------------------------
-Wed Feb 10, 11:00:00 PST 2016 - rhenalsj@amazon.com - 1.8.0-1
+Wed Feb 10, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.0-1
 
 - Cache Agent version 1.8.0
 -------------------------------------------------------------------
-Fri Jan 08, 11:00:00 PST 2016 - skarp@amazon.com - 1.7.1-1
+Fri Jan 08, 19:00:00 UTC 2016 - skarp@amazon.com - 1.7.1-1
 
 - Cache Agent version 1.7.1
 -------------------------------------------------------------------
-Tue Dec 08, 11:00:00 PST 2015 - skarp@amazon.com - 1.7.0-1
+Tue Dec 08, 19:00:00 UTC 2015 - skarp@amazon.com - 1.7.0-1
 
 - Cache Agent version 1.7.0
 - Add support for Docker 1.9.1
 -------------------------------------------------------------------
-Wed Oct 21, 11:00:00 PST 2015 - skarp@amazon.com - 1.6.0-1
+Wed Oct 21, 19:00:00 UTC 2015 - skarp@amazon.com - 1.6.0-1
 
 - Cache Agent version 1.6.0
 - Updated source dependencies
 -------------------------------------------------------------------
-Wed Sep 23, 11:00:00 PST 2015 - skarp@amazon.com - 1.5.0-1
+Wed Sep 23, 19:00:00 UTC 2015 - skarp@amazon.com - 1.5.0-1
 
 - Cache Agent version 1.5.0
 - Improved merge strategy for user-supplied environment variables
 - Add default supported logging drivers
 -------------------------------------------------------------------
-Wed Aug 26, 11:00:00 PST 2015 - skarp@amazon.com - 1.4.0-2
+Wed Aug 26, 19:00:00 UTC 2015 - skarp@amazon.com - 1.4.0-2
 
 - Add support for Docker 1.7.1
 -------------------------------------------------------------------
-Tue Aug 11, 11:00:00 PST 2015 - skarp@amazon.com - 1.4.0-1
+Tue Aug 11, 19:00:00 UTC 2015 - skarp@amazon.com - 1.4.0-1
 
 - Cache Agent version 1.4.0
 -------------------------------------------------------------------
-Thu Jul 30, 11:00:00 PST 2015 - skarp@amazon.com - 1.3.1-1
+Thu Jul 30, 19:00:00 UTC 2015 - skarp@amazon.com - 1.3.1-1
 
 - Cache Agent version 1.3.1
 - Read Docker endpoint from environment variable DOCKER_HOST if present
 -------------------------------------------------------------------
-Thu Jul 02, 11:00:00 PST 2015 - skarp@amazon.com - 1.3.0-1
+Thu Jul 02, 19:00:00 UTC 2015 - skarp@amazon.com - 1.3.0-1
 
 - Cache Agent version 1.3.0
 -------------------------------------------------------------------
-Fri Jun 19, 11:00:00 PST 2015 - euank@amazon.com - 1.2.1-2
+Fri Jun 19, 19:00:00 UTC 2015 - euank@amazon.com - 1.2.1-2
 
 - Cache Agent version 1.2.1
 -------------------------------------------------------------------
-Tue Jun 02, 11:00:00 PST 2015 - skarp@amazon.com - 1.2.0-1
+Tue Jun 02, 19:00:00 UTC 2015 - skarp@amazon.com - 1.2.0-1
 
 - Update versioning scheme to match Agent version
 - Cache Agent version 1.2.0
 - Mount cgroup and execdriver directories for Telemetry feature
 -------------------------------------------------------------------
-Mon Jun 01, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-5
+Mon Jun 01, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-5
 
 - Add support for Docker 1.6.2
 -------------------------------------------------------------------
-Mon May 11, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-4
+Mon May 11, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-4
 
 - Properly restart if the ecs-init package is upgraded in isolation
 -------------------------------------------------------------------
-Wed May 06, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-3
+Wed May 06, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-3
 
 - Restart on upgrade if already running
 -------------------------------------------------------------------
-Tue May 05, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-2
+Tue May 05, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-2
 
 - Cache Agent version 1.1.0
 - Add support for Docker 1.6.0
 - Force cache load on install/upgrade
 - Add man page
 -------------------------------------------------------------------
-Thu Mar 26, 11:00:00 PST 2015 - skarp@amazon.com - 1.0-1
+Thu Mar 26, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-1
 
 - Re-start Agent on non-terminal exit codes
 - Enable Agent self-updates
 - Cache Agent version 1.0.0
 - Added rollback to cached Agent version for failed updates
 -------------------------------------------------------------------
-Mon Mar 16, 11:00:00 PST 2015 - skarp@amazon.com - 0.3-0
+Mon Mar 16, 19:00:00 UTC 2015 - skarp@amazon.com - 0.3-0
 
 - Migrate to statically-compiled Go binary
 -------------------------------------------------------------------
-Tue Feb 17, 11:00:00 PST 2015 - ericn@amazon.com - 0.2-3
+Tue Feb 17, 19:00:00 UTC 2015 - ericn@amazon.com - 0.2-3
 
 - Test for existing container agent and force remove it
 -------------------------------------------------------------------
-Thu Jan 15, 11:00:00 PST 2015 - skarp@amazon.com - 0.2-2
+Thu Jan 15, 19:00:00 UTC 2015 - skarp@amazon.com - 0.2-2
 
 - Mount data directory for state persistence
 - Enable JSON-based configuration
 -------------------------------------------------------------------
-Mon Dec 15, 11:00:00 PST 2014 - skarp@amazon.com - 0.2-1
+Mon Dec 15, 19:00:00 UTC 2014 - skarp@amazon.com - 0.2-1
 
 - Naive update functionality

--- a/packaging/ubuntu-trusty/debian/changelog
+++ b/packaging/ubuntu-trusty/debian/changelog
@@ -3,161 +3,161 @@ amazon-ecs-init (1.37.0-2) trusty; urgency=medium
   * Cache Agent version 1.37.0
   * Add '/etc/alternatives' to mounts
 
- -- Jessie Young <youngli@amazon.com>  Fri, 21 Feb 2020 17:40:00 -0800
+ -- Jessie Young <youngli@amazon.com>  Sat, 22 Feb 2020 01:40:00 +0000
 
 amazon-ecs-init (1.36.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.36.2
   * update sbin mount point to avoid conflict with Docker >= 19.03.5
 
- -- Ray Allan <fierlion@amazon.com>  Tue, 04 Feb 2020 14:32:00 -0800
+ -- Ray Allan <fierlion@amazon.com>  Tue, 04 Feb 2020 22:32:00 +0000
 
 amazon-ecs-init (1.36.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.36.1
 
- -- Yunhee Lee <yhlee@amazon.com>  Fri, 10 Jan 2020 11:00:00 -0800
+ -- Yunhee Lee <yhlee@amazon.com>  Fri, 10 Jan 2020 19:00:00 +0000
 
 amazon-ecs-init (1.36.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.36.0
   * capture a fixed tail of container logs when removing a container
 
- -- Cameron Sparr <cssparr@amazon.com>  Wed, 08 Jan 2020 11:00:00 -0800
+ -- Cameron Sparr <cssparr@amazon.com>  Wed, 08 Jan 2020 19:00:00 +0000
 
 amazon-ecs-init (1.35.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.35.0
   * Fix bug where stopping agent gracefully would still restart ecs-init
 
- -- Derek Petersen <petderek@amazon.com>  Thu, 12 Dec 2019 09:00:00 -0800
+ -- Derek Petersen <petderek@amazon.com>  Thu, 12 Dec 2019 17:00:00 +0000
 
 amazon-ecs-init (1.33.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.33.0
   * Fix destination path in docker socket bind mount to match the one specified using DOCKER_HOST on Amazon Linux 2
 
- -- Shubham Goyal <shugy@amazon.com>  Mon, 11 Nov 2019 09:00:00 -0800
+ -- Shubham Goyal <shugy@amazon.com>  Mon, 11 Nov 2019 17:00:00 +0000
 
 amazon-ecs-init (1.32.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.32.1
   * Add the ability to set Agent container's labels
 
- -- Shubham Goyal <shugy@amazon.com>  Mon, 28 Oct 2019 09:00:00 -0800
+ -- Shubham Goyal <shugy@amazon.com>  Mon, 28 Oct 2019 17:00:00 +0000
 
 amazon-ecs-init (1.32.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.32.0
 
- -- Cameron Sparr <cssparr@amazon.com>  Wed, 25 Sep 2019 10:00:00 -0800
+ -- Cameron Sparr <cssparr@amazon.com>  Wed, 25 Sep 2019 18:00:00 +0000
 
 amazon-ecs-init (1.31.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.31.0
 
- -- Yajie Chu <cya@amazon.com>  Fri, 13 Sep 2019 10:00:00 -0800
+ -- Yajie Chu <cya@amazon.com>  Fri, 13 Sep 2019 18:00:00 +0000
 
 amazon-ecs-init (1.30.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.30.0
 
- -- Feng Xiong <fenxiong@amazon.com>  Thu, 15 Aug 2019 10:00:00 -0800
+ -- Feng Xiong <fenxiong@amazon.com>  Thu, 15 Aug 2019 18:00:00 +0000
 
 amazon-ecs-init (1.29.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.29.1
 
- -- Shubham Goyal <shugy@amazon.com>  Mon, 08 Jul 2019 11:06:00 -0800
+ -- Shubham Goyal <shugy@amazon.com>  Mon, 08 Jul 2019 19:06:00 +0000
 
 amazon-ecs-init (1.29.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.29.0
 
- -- Yumeng Xie <yumex@amazon.com>  Thu, 06 Jun 2019 14:47:00 -0800
+ -- Yumeng Xie <yumex@amazon.com>  Thu, 06 Jun 2019 22:47:00 +0000
 
 amazon-ecs-init (1.28.1-2) trusty; urgency=medium
 
   * Cache Agent version 1.28.1
   * Use exponential backoff when restarting agent
 
- -- Feng Xiong <fenxiong@amazon.com>  Fri, 31 May 2019 10:00:00 -0800
+ -- Feng Xiong <fenxiong@amazon.com>  Fri, 31 May 2019 18:00:00 +0000
 
 amazon-ecs-init (1.28.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.28.0
 
- -- Feng Xiong <fenxiong@amazon.com>  Thu, 09 May 2019 10:00:00 -0800
+ -- Feng Xiong <fenxiong@amazon.com>  Thu, 09 May 2019 18:00:00 +0000
 
 amazon-ecs-init (1.27.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.27.0
 
- -- Shaobo Han <obo@amazon.com>  Thu, 28 Mar 2019 14:00:00 -0800
+ -- Shaobo Han <obo@amazon.com>  Thu, 28 Mar 2019 22:00:00 +0000
 
 amazon-ecs-init (1.26.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.26.1
 
- -- Derek Petersen <petderek@amazon.com>  Thu, 21 Mar 2019 13:30:00 -0800
+ -- Derek Petersen <petderek@amazon.com>  Thu, 21 Mar 2019 21:30:00 +0000
 
 amazon-ecs-init (1.26.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.26.0
   * Add support for running iptables within agent container
 
- -- Derek Petersen <petderek@amazon.com>  Thu, 28 Feb 2019 13:30:00 -0800
+ -- Derek Petersen <petderek@amazon.com>  Thu, 28 Feb 2019 21:30:00 +0000
 
 amazon-ecs-init (1.25.3-1) trusty; urgency=medium
 
   * Cache Agent version 1.25.3
 
- -- Ray Allan <fierlion@amazon.com>  Fri, 15 Feb 2019 11:30:00 -0800
+ -- Ray Allan <fierlion@amazon.com>  Fri, 15 Feb 2019 19:30:00 +0000
 
 amazon-ecs-init (1.25.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.25.2
 
- -- Shaobo Han <obo@amazon.com>  Thu, 31 Jan 2019 11:53:00 -0800
+ -- Shaobo Han <obo@amazon.com>  Thu, 31 Jan 2019 19:53:00 +0000
 
 amazon-ecs-init (1.25.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.25.1
   * Update ecr models for private link support
 
- -- Adnan Khan <adnkha@amazon.com>  Fri, 25 Jan 2019 20:39:00 -0800
+ -- Adnan Khan <adnkha@amazon.com>  Sat, 26 Jan 2019 04:39:00 +0000
 
 amazon-ecs-init (1.25.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.25.0
   * Add Nvidia GPU support for p2 and p3 instances
 
- -- Eric Sun <yuzhusun@amazon.com>  Thu, 17 Jan 2019 10:32:18 -0800
+ -- Eric Sun <yuzhusun@amazon.com>  Thu, 17 Jan 2019 18:32:18 +0000
 
 amazon-ecs-init (1.24.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.24.0
 
- -- Eric Sun <yuzhusun@amazon.com>  Fri, 04 Jan 2019 10:16:18 -0800
+ -- Eric Sun <yuzhusun@amazon.com>  Fri, 04 Jan 2019 18:16:18 +0000
 
 amazon-ecs-init (1.22.0-4) trusty; urgency=medium
 
   * Cache ECS agent version 1.22.0 for x86_64 & ARM
   * Support ARM architecture builds
 
- -- Jacob Vallejo <jakeev@amazon.com>  Fri, 16 Nov 2018 11:00:00 -0800
+ -- Jacob Vallejo <jakeev@amazon.com>  Fri, 16 Nov 2018 19:00:00 +0000
 
 amazon-ecs-init (1.22.0-3) trusty; urgency=medium
 
   * Rebuild
 
- -- Jacob Vallejo <jakeev@amazon.com>   Thu, 15 Nov 2018 11:00:00 -0800
+ -- Jacob Vallejo <jakeev@amazon.com>   Thu, 15 Nov 2018 19:00:00 +0000
 
 amazon-ecs-init (1.22.0-2) trusty; urgency=medium
 
   * Cache Agent version 1.22.0
 
- -- Yunhee Lee <yhlee@amazon.com>  Fri, 02 Nov 2018 09:51:28 -0800
+ -- Yunhee Lee <yhlee@amazon.com>  Fri, 02 Nov 2018 17:51:28 +0000
 
 amazon-ecs-init (1.21.0-1) trusty; urgency=medium
 
@@ -165,50 +165,50 @@ amazon-ecs-init (1.21.0-1) trusty; urgency=medium
   * Support configurable logconfig for Agent container to reduce disk usage
   * ECS Agent will use the host's cert store on the Amazon Linux platform
 
- -- Sharanya Devaraj <sharanyd@amazon.com>  Thu, 11 Oct 2018 10:49:28 -0800
+ -- Sharanya Devaraj <sharanyd@amazon.com>  Thu, 11 Oct 2018 18:49:28 +0000
 
 amazon-ecs-init (1.20.3-1) trusty; urgency=medium
 
   * Cache Agent version 1.20.3
 
- -- Yumeng Xie <yumex@amazon.com>  Thu, 13 Sep 2018 16:38:10 -0800
+ -- Yumeng Xie <yumex@amazon.com>  Fri, 14 Sep 2018 00:38:10 +0000
 
 amazon-ecs-init (1.20.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.20.2
 
- -- Feng Xiong <fenxiong@amazon.com>  Thu, 30 Aug 2018 16:43:01 -0800
+ -- Feng Xiong <fenxiong@amazon.com>  Fri, 31 Aug 2018 00:43:01 +0000
 
 amazon-ecs-init (1.20.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.20.1
 
- -- Peng Yin <penyin@amazon.com>  Wed, 08 Aug 2018 16:04:01 -0800
+ -- Peng Yin <penyin@amazon.com>  Thu, 09 Aug 2018 00:04:01 +0000
 
 amazon-ecs-init (1.20.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.20.0
 
- -- Haikuo Liu <haikuo@amazon.com>  Wed, 01 Aug 2018 15:44:01 -0800
+ -- Haikuo Liu <haikuo@amazon.com>  Wed, 01 Aug 2018 23:44:01 +0000
 
 amazon-ecs-init (1.19.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.19.1
 
- -- Haikuo Liu <haikuo@amazon.com>  Thu, 26 Jul 2018 13:31:24 -0800
+ -- Haikuo Liu <haikuo@amazon.com>  Thu, 26 Jul 2018 21:31:24 +0000
 
 amazon-ecs-init (1.19.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.19.0
 
- -- Feng Xiong <fenxiong@amazon.com>  Thu, 19 Jul 2018 15:09:41 -0800
+ -- Feng Xiong <fenxiong@amazon.com>  Thu, 19 Jul 2018 23:09:41 +0000
 
 amazon-ecs-init (1.18.0-2) trusty; urgency=medium
 
   * Spec file cleanups
   * Enable builds for both AL1 and AL2
 
- -- iliana weller <iweller@amazon.com>   Wed, 23 May 2018 11:00:00 -0800
+ -- iliana weller <iweller@amazon.com>   Wed, 23 May 2018 19:00:00 +0000
 
 amazon-ecs-init (1.18.0-1) trusty; urgency=medium
 
@@ -218,82 +218,82 @@ amazon-ecs-init (1.18.0-1) trusty; urgency=medium
   * Download agent based on the partition
   * Mount Docker plugin files dir
 
- -- Haikuo Liu <haikuo@amazon.com>  Fri, 04 May 2018 13:30:22 -0800
+ -- Haikuo Liu <haikuo@amazon.com>  Fri, 04 May 2018 21:30:22 +0000
 
 amazon-ecs-init (1.17.3-1) trusty; urgency=medium
 
   * Cache Agent version 1.17.3
   * Use s3client instead of httpclient when downloading
 
- -- Justin Haynes <jushay@amazon.com>  Fri, 30 Mar 2018 12:20:41 -0800
+ -- Justin Haynes <jushay@amazon.com>  Fri, 30 Mar 2018 20:20:41 +0000
 
 amazon-ecs-init (1.17.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.17.2
 
- -- Jacob Vallejo <jakeev@amazon.com>  Mon, 05 Mar 2018 10:31:19 -0800
+ -- Jacob Vallejo <jakeev@amazon.com>  Mon, 05 Mar 2018 18:31:19 +0000
 
 amazon-ecs-init (1.17.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.17.1
 
- -- Justin Haynes <jushay@amazon.com>  Mon, 19 Feb 2018 10:57:33 -0800
+ -- Justin Haynes <jushay@amazon.com>  Mon, 19 Feb 2018 18:57:33 +0000
 
 amazon-ecs-init (1.17.0-2) trusty; urgency=medium
 
   * Cache Agent version 1.17.0
 
- -- Justin Haynes <jushay@amazon.com>  Mon, 05 Feb 2018 10:03:33 -0800
+ -- Justin Haynes <jushay@amazon.com>  Mon, 05 Feb 2018 18:03:33 +0000
 
 amazon-ecs-init (1.16.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.16.2
   * Add GovCloud endpoint
 
- -- Derek Petersen <petderek@amazon.com>  Tue, 16 Jan 2018 10:12:56 -0800
+ -- Derek Petersen <petderek@amazon.com>  Tue, 16 Jan 2018 18:12:56 +0000
 
 amazon-ecs-init (1.16.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.16.1
   * Improve startup behavior when Docker socket doesn't exist yet
 
- -- Noah Meyerhans <nmeyerha@amazon.com>  Wed, 03 Jan 2018 14:52:56 -0800
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Wed, 03 Jan 2018 22:52:56 +0000
 
 amazon-ecs-init (1.16.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.16.0
 
- -- Noah Meyerhans <nmeyerha@amazon.com>  Tue, 21 Nov 2017 13:03:59 -0800
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Tue, 21 Nov 2017 21:03:59 +0000
 
 amazon-ecs-init (1.15.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.15.2
 
- -- Noah Meyerhans <nmeyerha@amazon.com>  Tue, 14 Nov 2017 16:53:54 -0800
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Wed, 15 Nov 2017 00:53:54 +0000
 
 amazon-ecs-init (1.15.1-1) trusty; urgency=medium
 
   * Update ECS Agent version
 
- -- Jacob Vallejo <jakeev@amazon.com>  Tue, 17 Oct 2017 07:55:19 -0800
+ -- Jacob Vallejo <jakeev@amazon.com>  Tue, 17 Oct 2017 15:55:19 +0000
 
 amazon-ecs-init (1.15.0-1) trusty; urgency=medium
 
   * Update ECS Agent version
 
- -- Justin Haynes <jushay@amazon.com>  Fri, 06 Oct 2017 23:50:23 -0800
+ -- Justin Haynes <jushay@amazon.com>  Sat, 07 Oct 2017 07:50:23 +0000
 
 amazon-ecs-init (1.14.5-1) trusty; urgency=medium
 
   * Update ECS Agent version
 
- -- Justin Haynes <jushay@amazon.com>  Fri, 29 Sep 2017 17:36:34 -0800
+ -- Justin Haynes <jushay@amazon.com>  Sat, 30 Sep 2017 01:36:34 +0000
 
 amazon-ecs-init (1.14.4-1) trusty; urgency=medium
 
   * Update ECS Agent version
 
- -- Justin Haynes <jushay@amazon.com>  Tue, 22 Aug 2017 15:44:03 -0800
+ -- Justin Haynes <jushay@amazon.com>  Tue, 22 Aug 2017 23:44:03 +0000
 
 amazon-ecs-init (1.14.2-2) trusty; urgency=medium
 
@@ -301,68 +301,68 @@ amazon-ecs-init (1.14.2-2) trusty; urgency=medium
   * Add functionality for running agent with userns=host when Docker has userns-remap enabled
   * Add support for Docker 17.03.1ce
 
- -- Adnan Khan <adnkha@amazon.com>  Thu, 01 Jun 2017 11:00:00 -0800
+ -- Adnan Khan <adnkha@amazon.com>  Thu, 01 Jun 2017 19:00:00 +0000
 
 amazon-ecs-init (1.14.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.14.1
 
- -- Adnan Khan <adnkha@amazon.com>  Mon, 06 Mar 2017 11:00:00 -0800
+ -- Adnan Khan <adnkha@amazon.com>  Mon, 06 Mar 2017 19:00:00 +0000
 
 amazon-ecs-init (1.14.0-2) trusty; urgency=medium
 
   * Add retry-backoff for pinging the Docker socket when creating the Docker client
 
- -- Anirudh Aithal <aithal@amazon.com>  Wed, 25 Jan 2017 11:00:00 -0800
+ -- Anirudh Aithal <aithal@amazon.com>  Wed, 25 Jan 2017 19:00:00 +0000
 
 amazon-ecs-init (1.14.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.14.0
 
- -- Derek Petersen <petderek@amazon.com>  Mon, 16 Jan 2017 11:00:00 -0800
+ -- Derek Petersen <petderek@amazon.com>  Mon, 16 Jan 2017 19:00:00 +0000
 
 amazon-ecs-init (1.13.1-2) trusty; urgency=medium
 
   * Update Requires to indicate support for docker <= 1.12.6
 
- -- Noah Meyerhans <nmeyerha@amazon.com>  Fri, 06 Jan 2017 11:00:00 -0800
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Fri, 06 Jan 2017 19:00:00 +0000
 
 amazon-ecs-init (1.13.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.13.1
 
- -- Peng Yin <penyin@amazon.com>  Mon, 14 Nov 2016 11:00:00 -0800
+ -- Peng Yin <penyin@amazon.com>  Mon, 14 Nov 2016 19:00:00 +0000
 
 amazon-ecs-init (1.13.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.13.0
 
- -- Noah Meyerhans <nmeyerha@amazon.com>  Tue, 27 Sep 2016 11:00:00 -0800
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Tue, 27 Sep 2016 19:00:00 +0000
 
 amazon-ecs-init (1.12.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.12.2
 
- -- Anirudh Aithal <aithal@amazon.com>  Tue, 13 Sep 2016 11:00:00 -0800
+ -- Anirudh Aithal <aithal@amazon.com>  Tue, 13 Sep 2016 19:00:00 +0000
 
 amazon-ecs-init (1.12.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.12.1
 
- -- Peng Yin <penyin@amazon.com>  Wed, 17 Aug 2016 11:00:00 -0800
+ -- Peng Yin <penyin@amazon.com>  Wed, 17 Aug 2016 19:00:00 +0000
 
 amazon-ecs-init (1.12.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.12.0
   * Add netfilter rules to support host network reaching credentials proxy
 
- -- Anirudh Aithal <aithal@amazon.com>  Wed, 10 Aug 2016 11:00:00 -0800
+ -- Anirudh Aithal <aithal@amazon.com>  Wed, 10 Aug 2016 19:00:00 +0000
 
 amazon-ecs-init (1.11.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.11.1
 
- -- Samuel Karp <skarp@amazon.com>  Wed, 03 Aug 2016 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Wed, 03 Aug 2016 19:00:00 +0000
 
 amazon-ecs-init (1.11.0-1) trusty; urgency=medium
 
@@ -372,59 +372,59 @@ amazon-ecs-init (1.11.0-1) trusty; urgency=medium
   * Eliminate requirement that /tmp and /var/cache be on the same filesystem
   * Start agent with host network mode
 
- -- Samuel Karp <skarp@amazon.com>  Tue, 05 Jul 2016 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Tue, 05 Jul 2016 19:00:00 +0000
 
 amazon-ecs-init (1.10.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.10.0
   * Add support for Docker 1.11.1
 
- -- Peng Yin <penyin@amazon.com>  Mon, 23 May 2016 11:00:00 -0800
+ -- Peng Yin <penyin@amazon.com>  Mon, 23 May 2016 19:00:00 +0000
 
 amazon-ecs-init (1.9.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.9.0
   * Make awslogs driver available by default
 
- -- Peng Yin <penyin@amazon.com>  Tue, 26 Apr 2016 11:00:00 -0800
+ -- Peng Yin <penyin@amazon.com>  Tue, 26 Apr 2016 19:00:00 +0000
 
 amazon-ecs-init (1.8.2-1) trusty; urgency=medium
 
   * Cache Agent version 1.8.2
 
- -- Juan Rhenals <rhenalsj@amazon.com>  Thu, 24 Mar 2016 11:00:00 -0800
+ -- Juan Rhenals <rhenalsj@amazon.com>  Thu, 24 Mar 2016 19:00:00 +0000
 
 amazon-ecs-init (1.8.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.8.1
 
- -- Juan Rhenals <rhenalsj@amazon.com>  Mon, 29 Feb 2016 11:00:00 -0800
+ -- Juan Rhenals <rhenalsj@amazon.com>  Mon, 29 Feb 2016 19:00:00 +0000
 
 amazon-ecs-init (1.8.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.8.0
 
- -- Juan Rhenals <rhenalsj@amazon.com>  Wed, 10 Feb 2016 11:00:00 -0800
+ -- Juan Rhenals <rhenalsj@amazon.com>  Wed, 10 Feb 2016 19:00:00 +0000
 
 amazon-ecs-init (1.7.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.7.1
 
- -- Samuel Karp <skarp@amazon.com>  Fri, 08 Jan 2016 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Fri, 08 Jan 2016 19:00:00 +0000
 
 amazon-ecs-init (1.7.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.7.0
   * Add support for Docker 1.9.1
 
- -- Samuel Karp <skarp@amazon.com>  Tue, 08 Dec 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Tue, 08 Dec 2015 19:00:00 +0000
 
 amazon-ecs-init (1.6.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.6.0
   * Updated source dependencies
 
- -- Samuel Karp <skarp@amazon.com>  Wed, 21 Oct 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Wed, 21 Oct 2015 19:00:00 +0000
 
 amazon-ecs-init (1.5.0-1) trusty; urgency=medium
 
@@ -432,38 +432,38 @@ amazon-ecs-init (1.5.0-1) trusty; urgency=medium
   * Improved merge strategy for user-supplied environment variables
   * Add default supported logging drivers
 
- -- Samuel Karp <skarp@amazon.com>  Wed, 23 Sep 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Wed, 23 Sep 2015 19:00:00 +0000
 
 amazon-ecs-init (1.4.0-2) trusty; urgency=medium
 
   * Add support for Docker 1.7.1
 
- -- Samuel Karp <skarp@amazon.com>  Wed, 26 Aug 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Wed, 26 Aug 2015 19:00:00 +0000
 
 amazon-ecs-init (1.4.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.4.0
 
- -- Samuel Karp <skarp@amazon.com>  Tue, 11 Aug 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Tue, 11 Aug 2015 19:00:00 +0000
 
 amazon-ecs-init (1.3.1-1) trusty; urgency=medium
 
   * Cache Agent version 1.3.1
   * Read Docker endpoint from environment variable DOCKER_HOST if present
 
- -- Samuel Karp <skarp@amazon.com>  Thu, 30 Jul 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Thu, 30 Jul 2015 19:00:00 +0000
 
 amazon-ecs-init (1.3.0-1) trusty; urgency=medium
 
   * Cache Agent version 1.3.0
 
- -- Samuel Karp <skarp@amazon.com>  Thu, 02 Jul 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Thu, 02 Jul 2015 19:00:00 +0000
 
 amazon-ecs-init (1.2.1-2) trusty; urgency=medium
 
   * Cache Agent version 1.2.1
 
- -- Euan Kemp <euank@amazon.com>  Fri, 19 Jun 2015 11:00:00 -0800
+ -- Euan Kemp <euank@amazon.com>  Fri, 19 Jun 2015 19:00:00 +0000
 
 amazon-ecs-init (1.2.0-1) trusty; urgency=medium
 
@@ -471,25 +471,25 @@ amazon-ecs-init (1.2.0-1) trusty; urgency=medium
   * Cache Agent version 1.2.0
   * Mount cgroup and execdriver directories for Telemetry feature
 
- -- Samuel Karp <skarp@amazon.com>  Tue, 02 Jun 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Tue, 02 Jun 2015 19:00:00 +0000
 
 amazon-ecs-init (1.0-5) trusty; urgency=medium
 
   * Add support for Docker 1.6.2
 
- -- Samuel Karp <skarp@amazon.com>  Mon, 01 Jun 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Mon, 01 Jun 2015 19:00:00 +0000
 
 amazon-ecs-init (1.0-4) trusty; urgency=medium
 
   * Properly restart if the ecs-init package is upgraded in isolation
 
- -- Samuel Karp <skarp@amazon.com>  Mon, 11 May 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Mon, 11 May 2015 19:00:00 +0000
 
 amazon-ecs-init (1.0-3) trusty; urgency=medium
 
   * Restart on upgrade if already running
 
- -- Samuel Karp <skarp@amazon.com>  Wed, 06 May 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Wed, 06 May 2015 19:00:00 +0000
 
 amazon-ecs-init (1.0-2) trusty; urgency=medium
 
@@ -498,7 +498,7 @@ amazon-ecs-init (1.0-2) trusty; urgency=medium
   * Force cache load on install/upgrade
   * Add man page
 
- -- Samuel Karp <skarp@amazon.com>  Tue, 05 May 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Tue, 05 May 2015 19:00:00 +0000
 
 amazon-ecs-init (1.0-1) trusty; urgency=medium
 
@@ -507,30 +507,30 @@ amazon-ecs-init (1.0-1) trusty; urgency=medium
   * Cache Agent version 1.0.0
   * Added rollback to cached Agent version for failed updates
 
- -- Samuel Karp <skarp@amazon.com>  Thu, 26 Mar 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Thu, 26 Mar 2015 19:00:00 +0000
 
 amazon-ecs-init (0.3-0) trusty; urgency=medium
 
   * Migrate to statically-compiled Go binary
 
- -- Samuel Karp <skarp@amazon.com>  Mon, 16 Mar 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Mon, 16 Mar 2015 19:00:00 +0000
 
 amazon-ecs-init (0.2-3) trusty; urgency=medium
 
   * Test for existing container agent and force remove it
 
- -- Eric Nordlund <ericn@amazon.com>  Tue, 17 Feb 2015 11:00:00 -0800
+ -- Eric Nordlund <ericn@amazon.com>  Tue, 17 Feb 2015 19:00:00 +0000
 
 amazon-ecs-init (0.2-2) trusty; urgency=medium
 
   * Mount data directory for state persistence
   * Enable JSON-based configuration
 
- -- Samuel Karp <skarp@amazon.com>  Thu, 15 Jan 2015 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Thu, 15 Jan 2015 19:00:00 +0000
 
 amazon-ecs-init (0.2-1) trusty; urgency=medium
 
   * Naive update functionality
 
- -- Samuel Karp <skarp@amazon.com>  Mon, 15 Dec 2014 11:00:00 -0800
+ -- Samuel Karp <skarp@amazon.com>  Mon, 15 Dec 2014 19:00:00 +0000
 

--- a/scripts/changelog/README.md
+++ b/scripts/changelog/README.md
@@ -3,13 +3,13 @@
 ## Be sure your git is clean
 We'll be relying on git to guard us against problems.
 Staring from a clean checkout follow these steps.
- 
-## Update CHANGELOG\_MASTER
-The CHANGELOG\_MASTER consists of 
 
-version (Name.Version.Release) 
+## Update CHANGELOG\_MASTER
+The CHANGELOG\_MASTER consists of
+
+version (Name.Version.Release)
 User <user@email>
-Datetime(RFC1123 format) 
+Datetime(RFC1123 format)
 List of changes separated by newline
 Newline
 
@@ -25,9 +25,7 @@ You'll need to add a new entry to the CHANGELOG\_MASTER before running the
 chagelog.go script
 
 ## Build and run changelog.go
-From the scripts/changelog dir, build the changelog binary with `go build changelog.go`
-run the built changelog binary from this same directory.  It uses relative
-paths to replace the relevant changelog files: `./changelog`
+From the scripts/changelog dir, build and run the changelog binary with `go run ./changelog.go`
 
 use git status to check that the following files are updated
 ```

--- a/scripts/changelog/changelog.go
+++ b/scripts/changelog/changelog.go
@@ -25,8 +25,6 @@ const (
 	AMAZON_LINUX_TIME_FMT = "Mon Jan 02 2006"
 	DEBIAN_TIME_FMT       = "Mon, 02 Jan 2006 15:04:05 -0700"
 	SUSE_TIME_FMT         = "Mon Jan 02, 15:04:05 MST 2006"
-
-	PST_CONV = "-0800"
 )
 
 func main() {
@@ -126,7 +124,7 @@ func validateChangelog(allChange []Change) bool {
 func getAmazonLinuxChangeString(allChange []Change) string {
 	result := ""
 	for _, change := range allChange {
-		thisTime := change.Datetime.Format(AMAZON_LINUX_TIME_FMT)
+		thisTime := change.Datetime.UTC().Format(AMAZON_LINUX_TIME_FMT)
 		result += fmt.Sprintf("* %s %s - %s\n", thisTime, change.Name, change.Version)
 		for _, update := range change.Changes {
 			result += fmt.Sprintf("- %s\n", update)
@@ -148,10 +146,7 @@ func getUbuntuChangeString(allChange []Change) string {
 	result := ""
 	for _, change := range allChange {
 		result += fmt.Sprintf("amazon-ecs-init (%s) trusty; urgency=medium\n\n", change.Version)
-		thisTime := change.Datetime.Format(DEBIAN_TIME_FMT)
-		// fix bug where time doesn't parse 'PST' to '-0800'
-		r := strings.NewReplacer("+0000", PST_CONV)
-		thisTime = r.Replace(thisTime)
+		thisTime := change.Datetime.UTC().Format(DEBIAN_TIME_FMT)
 		for _, update := range change.Changes {
 			result += fmt.Sprintf("  * %s\n", update)
 		}
@@ -173,7 +168,7 @@ func getSuseChangeString(allChange []Change) string {
 	result := ""
 	for _, change := range allChange {
 		result += fmt.Sprintf("-------------------------------------------------------------------\n")
-		thisTime := change.Datetime.Format(SUSE_TIME_FMT)
+		thisTime := change.Datetime.UTC().Format(SUSE_TIME_FMT)
 		thisEmail := getEmailSlice(change.Name)
 		result += fmt.Sprintf("%s - %s - %s\n\n", thisTime, thisEmail, change.Version)
 		for _, update := range change.Changes {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Outputting the time format in local time is problematic because it will change based on the operator's current timezone. Even if they are in Seattle this can change depending on the time of the year (PDT/PST).

This PR changes the output timestamps for all of the changelogs to be in UTC.


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
