### PR TITLE
add gocyclo, goimports target to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ install:
     - go get golang.org/x/tools/cover
     - go get golang.org/x/tools/cmd/cover
 script:
+    - make get-deps
     - make gotest
+    - make static-check

--- a/ecs-init/config/logger.go
+++ b/ecs-init/config/logger.go
@@ -34,7 +34,7 @@ and limitations under the License.
 <seelog type="asyncloop">
 	<outputs formatid="main">
 		<console formatid="console" />
-		<rollingfile filename="`+initLogFile()+`" type="date"
+		<rollingfile filename="` + initLogFile() + `" type="date"
 			 datepattern="2006-01-02-15" archivetype="zip" maxrolls="5" />
 	</outputs>
 	<formats>

--- a/ecs-init/docker/dependencies_test.go
+++ b/ecs-init/docker/dependencies_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/ecs-init/docker/docker_suse_ubuntu.go
+++ b/ecs-init/docker/docker_suse_ubuntu.go
@@ -15,7 +15,10 @@
 
 package docker
 
-import godocker "github.com/fsouza/go-dockerclient"
+import (
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
+	godocker "github.com/fsouza/go-dockerclient"
+)
 
 // getPlatformSpecificEnvVariables gets a map of environment variable key-value
 // pairs to set in the Agent's container config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
addresses https://github.com/aws/amazon-ecs-init/issues/298 
also fixes existing goimports errors 

### Implementation details
adds gocyclo, goimports and govet target to travis 
mostly reused from https://github.com/aws/amazon-ecs-agent/blob/master/Makefile 

### Testing
```
$ make static-check
# Run gocyclo over all .go files
gocyclo -over 15 /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/ecs-init.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/backoff/backoff.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/cache/cache.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/cache/dependencies.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/cache/dependencies_mocks.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/cmd/cmd.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/config/common.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/config/config_unspecified.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/config/logger.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/config/release.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/backoff_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/dependencies.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/dependencies_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/dependencies_unspecified.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/docker.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/docker/docker_unspecified.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/engine/dependencies.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/engine/dependencies_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/engine/engine.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/exec.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/iptables/cmd_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/iptables/exec_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/iptables/iptables.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/sysctl/cmd_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/sysctl/exec_mocks.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/exec/sysctl/sysctl.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/gpu/nvidia_gpu_manager.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/gpu/nvidia_gpu_manager_mocks.go  /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/version/formatting.go /home/ec2-user/go/src/github.com/aws/amazon-ecs-init/ecs-init/version/version.go
go vet github.com/aws/amazon-ecs-init/ecs-init github.com/aws/amazon-ecs-init/ecs-init/backoff github.com/aws/amazon-ecs-init/ecs-init/cache github.com/aws/amazon-ecs-init/ecs-init/cmd github.com/aws/amazon-ecs-init/ecs-init/config github.com/aws/amazon-ecs-init/ecs-init/docker github.com/aws/amazon-ecs-init/ecs-init/engine github.com/aws/amazon-ecs-init/ecs-init/exec github.com/aws/amazon-ecs-init/ecs-init/exec/iptables github.com/aws/amazon-ecs-init/ecs-init/exec/sysctl github.com/aws/amazon-ecs-init/ecs-init/gpu github.com/aws/amazon-ecs-init/ecs-init/version
```

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
