### PR TITLE
Remove volume from state when unmount failed with not mounted

### DIFF
--- a/ecs-init/volumes/ecs_volume_driver_test.go
+++ b/ecs-init/volumes/ecs_volume_driver_test.go
@@ -112,6 +112,26 @@ func TestRemoveVolumeHappyPath(t *testing.T) {
 	assert.Len(t, e.volumeMounts, 0)
 }
 
+func TestRemoveVolumeUnmounted(t *testing.T) {
+	e := NewECSVolumeDriver()
+	e.volumeMounts["vol"] = &MountHelper{}
+	req := RemoveRequest{
+		Name: "vol",
+	}
+	lookPath = func(string) (string, error) {
+		return "path", nil
+	}
+	runUnmount = func(string, string) error {
+		return errors.New("not mounted")
+	}
+	defer func() {
+		lookPath = getPath
+		runUnmount = runUnmountCommand
+	}()
+	assert.NoError(t, e.Remove(&req), "expected no error when unmount failed because of not mounted")
+	assert.Len(t, e.volumeMounts, 0)
+}
+
 func TestRemoveUnmountFailure(t *testing.T) {
 	e := NewECSVolumeDriver()
 	e.volumeMounts["vol"] = &MountHelper{}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Remove volume from state when unmount failed with not mounted.

Currently when the plugin tries to unmount a volume that isn't mounted, it fails and the volume stays in the state forever. An example case that this can happen is to reboot the instance when an EFS task is running. The EFS volume is unmounted after reboot and the volume can't be removed.

Fixing by treating unmount failed with "not mounted" error as success and let the plugin remove the volume from state in that case.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
See above.

### Testing
<!-- How was this tested? -->
Unit test added. Manually built rpm and tested that this fixed the issue.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
