### PR TITLE
Clean up mount path when mount failed

### DIFF
--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -173,6 +173,10 @@ func (a *AmazonECSVolumePlugin) Create(r *volume.CreateRequest) error {
 	err = volDriver.Create(req)
 	if err != nil {
 		seelog.Errorf("Volume %s creation failure: %v", r.Name, err)
+		cErr := a.CleanupMountPath(target)
+		if cErr != nil {
+			seelog.Warnf("Failed to cleanup mount path for volume %s: %v", r.Name, cErr)
+		}
 		return err
 	}
 	seelog.Infof("Volume %s created successfully", r.Name)

--- a/ecs-init/volumes/ecs_volume_plugin_test.go
+++ b/ecs-init/volumes/ecs_volume_plugin_test.go
@@ -189,11 +189,19 @@ func TestVolumeCreateFailure(t *testing.T) {
 	createMountPath = func(path string) error {
 		return nil
 	}
+
+	var removeInvoked bool
+	removeMountPath = func(path string) error {
+		removeInvoked = true
+		return nil
+	}
 	defer func() {
 		createMountPath = createMountDir
+		removeMountPath = deleteMountPath
 	}()
 	assert.Error(t, plugin.Create(req), "expected error while creating volume")
 	assert.Len(t, plugin.volumes, 0)
+	assert.True(t, removeInvoked)
 }
 
 func TestCreateNoVolumeType(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Currently, when mounting a volume failed for whatever reason, the mount path is left on the host. This PR adds the logic to cleanup the mount path in that case.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
See above.

### Testing
<!-- How was this tested? -->
Modified existing unit test. Manually tested that with the fix mount path is cleaned up when mount failed.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
