### PR TITLE
Fixup changelog from 1.38 release

### DIFF
--- a/packaging/suse/amazon-ecs-init.changes
+++ b/packaging/suse/amazon-ecs-init.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Mar 19, 13:42:00 UTC 2020 - sharanyd@amazon.com - 1.38.0-1
+Thu Mar 19, 21:42:00 UTC 2020 - sharanyd@amazon.com - 1.38.0-1
 
 - Cache Agent version 1.38.0
 - Adds support for ECS volume plugin

--- a/packaging/ubuntu-trusty/debian/changelog
+++ b/packaging/ubuntu-trusty/debian/changelog
@@ -4,7 +4,7 @@ amazon-ecs-init (1.38.0-1) trusty; urgency=medium
   * Adds support for ECS volume plugin
   * Disable ipv6 router advertisements for optimization
 
- -- Sharanya Devaraj <sharanyd@amazon.com>  Thu, 19 Mar 2020 13:42:00 +0000
+ -- Sharanya Devaraj <sharanyd@amazon.com>  Thu, 19 Mar 2020 21:42:00 +0000
 
 amazon-ecs-init (1.37.0-2) trusty; urgency=medium
 

--- a/scripts/changelog/CHANGELOG_MASTER
+++ b/scripts/changelog/CHANGELOG_MASTER
@@ -1,6 +1,6 @@
 1.38.0-1
 Sharanya Devaraj <sharanyd@amazon.com>
-Thu, 19 Mar 2020 13:42:00 PST
+2020-03-19T13:42:00-08:00
 Cache Agent version 1.38.0
 Adds support for ECS volume plugin
 Disable ipv6 router advertisements for optimization


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This is a follow-up to https://github.com/aws/amazon-ecs-init/pull/320

The above PR was merged before the 1.38.0-1 release staging branch was merged. This fixes up the 1.38 CHANGELOG_MASTER entry to be inline with the new rfc3339 format.


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
