### PR TITLE
Use -e flag when disabling ipv6 router advertisements

### DIFF
--- a/ecs-init/exec/sysctl/sysctl.go
+++ b/ecs-init/exec/sysctl/sysctl.go
@@ -69,7 +69,7 @@ func NewIpv6RouterAdvertisements(cmdExec exec.Exec) (*Ipv6RouterAdvertisements, 
 
 // Disable disables ipv6 router advertisements
 func (ra *Ipv6RouterAdvertisements) Disable() error {
-	cmd := ra.cmdExec.Command(sysctlExecutable, "-w", fmt.Sprintf("%s=0", dockerIpv6AcceptRAKey))
+	cmd := ra.cmdExec.Command(sysctlExecutable, "-e", "-w", fmt.Sprintf("%s=0", dockerIpv6AcceptRAKey))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Errorf("Error disable ipv6 router advertisements %v; raw output: %s", err, out)

--- a/ecs-init/exec/sysctl/sysctl_test.go
+++ b/ecs-init/exec/sysctl/sysctl_test.go
@@ -151,7 +151,7 @@ func TestDisableIpv6RouterAdvertisements(t *testing.T) {
 	mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil)
 	mockExec := NewMockExec(ctrl)
 	mockExec.EXPECT().LookPath(sysctlExecutable).Return("", nil)
-	mockExec.EXPECT().Command(sysctlExecutable, "-w", "net.ipv6.conf.docker0.accept_ra=0").Return(mockCmd)
+	mockExec.EXPECT().Command(sysctlExecutable, "-e", "-w", "net.ipv6.conf.docker0.accept_ra=0").Return(mockCmd)
 	ra, err := NewIpv6RouterAdvertisements(mockExec)
 	if err != nil {
 		t.Fatalf("Error creating NewIpv6RouterAdvertisements object: %v", err)
@@ -184,7 +184,7 @@ func TestDisableIpv6RouterAdvertisements_Error(t *testing.T) {
 	mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, fmt.Errorf("nope!"))
 	mockExec := NewMockExec(ctrl)
 	mockExec.EXPECT().LookPath(sysctlExecutable).Return("", nil)
-	mockExec.EXPECT().Command(sysctlExecutable, "-w", "net.ipv6.conf.docker0.accept_ra=0").Return(mockCmd)
+	mockExec.EXPECT().Command(sysctlExecutable, "-e", "-w", "net.ipv6.conf.docker0.accept_ra=0").Return(mockCmd)
 	ra, err := NewIpv6RouterAdvertisements(mockExec)
 	if err != nil {
 		t.Fatalf("Error creating NewIpv6RouterAdvertisements object: %v", err)


### PR DESCRIPTION
This is a follow-up to #313

Some customers might have already disabled ipv6 entirely, which would
mean that the ipv6 accept_ra sysctl key wouldn't exist. In this case,
the sysctl command would fail and the agent would exit.

The -e flag tells sysctl not to fail if the config key doesnt exist.
from sysctl man page:
-e
    Use this option to ignore errors about unknown keys.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
