### PR TITLE
Update Go version, Add staticcheck, fix code inefficiencies found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-    - 1.9
+    - 1.12
 before_install: ./scripts/hack/symlink-gopath-travisci
 install:
     - go get golang.org/x/tools/cover

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ static:
 	./scripts/gobuild.sh
 
 govet:
-	go vet $(shell go list ./ecs-init/...)
+	go vet ./...
 
 gotest:
 	go test -count=1 -short -v -cover ./...

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ importcheck:
 
 .PHONY: static-check
 static-check: gocyclo govet importcheck
+	# use default checks of staticcheck tool, except style checks (-ST*)
+	# https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck
+	staticcheck -tests=false -checks "inherit,-ST*" ./ecs-init/...
 
 test-in-docker:
 	docker build -f scripts/dockerfiles/test.dockerfile -t "amazon/amazon-ecs-init-test:make" .
@@ -113,6 +116,7 @@ get-deps:
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/fzipp/gocyclo
 	go get github.com/golang/mock/mockgen
+	go get honnef.co/go/tools/cmd/staticcheck
 
 clean:
 	-rm -f ecs-init.spec

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -458,11 +458,9 @@ func (c *Client) StopAgent() error {
 	}
 	stopContainerTimeoutSeconds := uint(10)
 	err = c.docker.StopContainer(id, stopContainerTimeoutSeconds)
-	if err != nil {
-		if _, ok := err.(*godocker.ContainerNotRunning); ok {
-			log.Info("Agent is already stopped")
-			return nil
-		}
+	if _, ok := err.(*godocker.ContainerNotRunning); ok {
+		log.Info("Agent is already stopped")
+		return nil
 	}
 	return err
 }

--- a/scripts/changelog/changelog.go
+++ b/scripts/changelog/changelog.go
@@ -85,7 +85,7 @@ func main() {
 		for scanner.Scan() {
 			line := scanner.Text()
 			if strings.Contains(line, "%changelog") {
-				amazonLinuxSpecBase += fmt.Sprintln("%changelog")
+				amazonLinuxSpecBase += "%changelog"
 				break
 			}
 			amazonLinuxSpecBase += fmt.Sprintln(line)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update Go version to 1.12.
Update static-check make target by adding staticcheck tool. Uses all default checks except code style check (-ST*).
Also fixes a golang inefficiency found by it.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
static-check make target is updated with the command to run the check

### Testing
<!-- How was this tested? -->
Tested using the updated static-check make target
`make static-check`

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
