### PR TITLE
Drop traffic to 127.0.0.1 that isn't originated from the host

### DIFF
--- a/ecs-init/exec/iptables/iptables.go
+++ b/ecs-init/exec/iptables/iptables.go
@@ -15,9 +15,11 @@ package iptables
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/amazon-ecs-init/ecs-init/exec"
 	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
 )
 
 // iptablesAction enumerates different actions for the iptables command
@@ -29,10 +31,16 @@ const (
 	credentialsProxyPort          = "80"
 	localhostIpAddress            = "127.0.0.1"
 	localhostCredentialsProxyPort = "51679"
+	localhostNetwork              = "127.0.0.0/8"
 	// iptablesAppend enumerates the 'append' action
 	iptablesAppend iptablesAction = "-A"
+	// iptablesInsert enumerates the 'insert' action
+	iptablesInsert iptablesAction = "-I"
 	// iptablesDelete enumerates the 'delete' action
 	iptablesDelete iptablesAction = "-D"
+
+	iptablesTableFilter = "filter"
+	iptablesTableNat    = "nat"
 )
 
 // NetfilterRoute implements the engine.credentialsProxyRoute interface by
@@ -61,38 +69,62 @@ func NewNetfilterRoute(cmdExec exec.Exec) (*NetfilterRoute, error) {
 
 // Create creates the credentials proxy endpoint route in the netfilter table
 func (route *NetfilterRoute) Create() error {
-	err := route.modifyNetfilterEntry(iptablesAppend, getPreroutingChainArgs)
+	err := route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getPreroutingChainArgs)
 	if err != nil {
 		return err
 	}
-	return route.modifyNetfilterEntry(iptablesAppend, getOutputChainArgs)
+
+	err = route.modifyNetfilterEntry(iptablesTableFilter, iptablesInsert, getInputChainArgs)
+	if err != nil {
+		return err
+	}
+
+	return route.modifyNetfilterEntry(iptablesTableNat, iptablesAppend, getOutputChainArgs)
 }
 
 // Remove removes the route for the credentials endpoint from the netfilter
 // table
 func (route *NetfilterRoute) Remove() error {
-	preroutingErr := route.modifyNetfilterEntry(iptablesDelete, getPreroutingChainArgs)
+	preroutingErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getPreroutingChainArgs)
 	if preroutingErr != nil {
 		// Add more context for error in modifying the prerouting chain
-		preroutingErr = fmt.Errorf("Error removing prerouting chain entry: %v", preroutingErr)
+		preroutingErr = fmt.Errorf("error removing prerouting chain entry: %v", preroutingErr)
 	}
-	outputErr := route.modifyNetfilterEntry(iptablesDelete, getOutputChainArgs)
+
+	inputErr := route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getInputChainArgs)
+	if inputErr != nil {
+		inputErr = fmt.Errorf("error removing input chain entry: %v", inputErr)
+	}
+
+	outputErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getOutputChainArgs)
 	if outputErr != nil {
-		if preroutingErr != nil {
-			// return a combined error message for prerouting and output chains
-			return fmt.Errorf("%v; Error removing output chain entry: %v", preroutingErr, outputErr)
-		}
 		// Add more context for error in modifying the output chain
-		return fmt.Errorf("Error removing output chain entry: %v", outputErr)
+		outputErr = fmt.Errorf("error removing output chain entry: %v", outputErr)
 	}
-	return preroutingErr
+
+	return combinedError(preroutingErr, inputErr, outputErr)
+}
+
+func combinedError(errs ...error) error {
+	errMsgs := []string{}
+	for _, err := range errs {
+		if err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+
+	if len(errMsgs) == 0 {
+		return nil
+	}
+
+	return errors.New(strings.Join(errMsgs, ";"))
 }
 
 // modifyNetfilterEntry modifies an entry in the netfilter table based on
 // the action and the function pointer to get arguments for modifying the
 // chain
-func (route *NetfilterRoute) modifyNetfilterEntry(action iptablesAction, getNetfilterChainArgs getNetfilterChainArgsFunc) error {
-	args := append(getNatTableArgs(), string(action))
+func (route *NetfilterRoute) modifyNetfilterEntry(table string, action iptablesAction, getNetfilterChainArgs getNetfilterChainArgsFunc) error {
+	args := append(getTableArgs(table), string(action))
 	args = append(args, getNetfilterChainArgs()...)
 	cmd := route.cmdExec.Command(iptablesExecutable, args...)
 	out, err := cmd.CombinedOutput()
@@ -103,8 +135,8 @@ func (route *NetfilterRoute) modifyNetfilterEntry(action iptablesAction, getNetf
 	return err
 }
 
-func getNatTableArgs() []string {
-	return []string{"-t", "nat"}
+func getTableArgs(table string) []string {
+	return []string{"-t", table}
 }
 
 func getPreroutingChainArgs() []string {
@@ -115,6 +147,17 @@ func getPreroutingChainArgs() []string {
 		"--dport", credentialsProxyPort,
 		"-j", "DNAT",
 		"--to-destination", localhostIpAddress + ":" + localhostCredentialsProxyPort,
+	}
+}
+
+func getInputChainArgs() []string {
+	return []string{
+		"INPUT",
+		"--dst", localhostNetwork,
+		"!", "--src", localhostNetwork,
+		"-m", "conntrack",
+		"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
+		"-j", "DROP",
 	}
 }
 
@@ -130,9 +173,12 @@ func getOutputChainArgs() []string {
 }
 
 func getActionName(action iptablesAction) string {
-	if action == iptablesAppend {
+	switch action {
+	case iptablesAppend:
 		return "append"
+	case iptablesInsert:
+		return "insert"
+	default:
+		return "delete"
 	}
-
-	return "delete"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? --> 
Add iptable rule to drop traffic to 127.0.0.1 that isn't originated from the host. This is necessitated by the fact that we set `net.ipv4.conf.all.route_localnet` to 1.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Add following iptable rule when starting up:
```
iptables -I INPUT --dst 127.0.0.0/8 ! --src 127.0.0.0/8 -m conntrack ! --ctstate RELATED,ESTABLISHED,DNAT -j DROP
```
Remove the rule upon stop.
Some refactor in unit test code to reduce duplicate code and use assert/require from testify library.

### Testing
<!-- How was this tested? -->
Unit tests added/updated.

Built the rpm and verified that the expected iptable rule is added after the sevice start:
```
[ec2-user@ip-xxx ~]$ sudo iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
DROP       all  -- !ip-127-0-0-0.us-west-2.compute.internal/8  ip-127-0-0-0.us-west-2.compute.internal/8  ! ctstate RELATED,ESTABLISHED,DNAT
```
and that the rule is removed when service stopped.
Ran a few agent functional tests with the rpm including the task iam role test to make sure the local traffic forwarding to task credential endpoint isn't affected.

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Drop traffic to 127.0.0.1 that isn't originated from the host.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
