### PR TITLE
Add a flag to allow skipping local traffic filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ configurations can be used to configure other properties of the ECS Agent contai
 |:----------------|:----------------------------|:------------|:-----------------------|
 | `ECS_AGENT_LABELS` | `{"test.label.1":"value1","test.label.2":"value2"}` | The labels to add to the ECS Agent container. | |
 
+Additionally, the following environment variable(s) can be used to configure the behavior of the RPM:
+
+| Environment Variable Name | Example Value(s)            | Description | Default value |
+|:----------------|:----------------------------|:------------|:-----------------------|
+| `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` | &lt;true &#124; false&gt; | By default, the ecs-init service adds an iptable rule to drop non-local packets to localhost if they're not part of an existing forwarded connection or DNAT, and removes the rule upon stop. If `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` is set to true, this rule will not be added/removed. | false |
+
 ## Usage
 The upstart script installed by the Amazon Elastic Container Service RPM can be started or stopped with the following commands respectively:
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Address https://github.com/aws/amazon-ecs-init/issues/336. Per https://github.com/aws/containers-roadmap/issues/976 for security purpose, an iptable rule is added to drop localhost traffic whose source address isn't in the localhost network and doesn't belong to an established connection/DNAT. As this can break some existing usage, adding a flag `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` to allow skipping local traffic filtering as a workaround.

On Amazon Linux 1, the flag can be turned on via adding `env ECS_SKIP_LOCALHOST_TRAFFIC_FILTER=true` to `/etc/init/ecs.conf`.
On Amazon Linux 2, the flag can be turned on via adding `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER=true` to `/etc/ecs/ecs.config`.


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Parse env ECS_SKIP_LOCALHOST_TRAFFIC_FILTER. If set to true, skip adding/removing the relevant iptable rule.


### Testing
<!-- How was this tested? -->
Unit tests added. Manually built an rpm and verified the rule is not added when the env is set to true.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Add a flag `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` to allow skipping local traffic filtering https://github.com/aws/amazon-ecs-init/pull/338.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
