### PR TITLE
Block offhost access to agent's introspection port by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Additionally, the following environment variable(s) can be used to configure the
 | Environment Variable Name | Example Value(s)            | Description | Default value |
 |:----------------|:----------------------------|:------------|:-----------------------|
 | `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` | &lt;true &#124; false&gt; | By default, the ecs-init service adds an iptable rule to drop non-local packets to localhost if they're not part of an existing forwarded connection or DNAT, and removes the rule upon stop. If `ECS_SKIP_LOCALHOST_TRAFFIC_FILTER` is set to true, this rule will not be added/removed. | false |
+| `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS` | &lt;true &#124; false&gt; | By default, the ecs-init service adds an iptable rule to block access to ECS Agent's introspection port from off-host (or containers in awsvpc network mode), and removes the rule upon stop. If `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS` is set to true, this rule will not be added/removed. | false |
 
 ## Usage
 The upstart script installed by the Amazon Elastic Container Service RPM can be started or stopped with the following commands respectively:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Block offhost access to agent's introspection port by default.

During start, add iptable rule "iptables -A INPUT -i eth0 -p tcp --dport 51678 -j DROP". This blocks:
(b.1) offhost access from same subnet over instance private ip: http://$(instance_private_ip):51678;
(b.2) any access over instance public ip: http://$(instance_public_ip):51678;
(b.3) any access from container in awsvpc network mode over instance private ip: http://$(instance_public_ip):51678

This allows:
(a.1) on instance access over instance private ip: http://$(instance_private_ip):51678
(a.2) on instance access over localhost: http://localhost:51678
(a.3) same instance, from container in host network mode, over localhost and private ip: http://localhost:51678 and http://$(instance_private_ip):51678;
(a.4) same instance, from container in bridge network mode, over private ip: http://$(instance_private_ip):51678

This behavior is configurable via env ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS (when set to true, the above mentioned rule is not added). To set this, for AL1, add `env ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS=true` to /etc/init/ecs.conf; for AL2, add `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS=true` to /etc/ecs/ecs.config.


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Added logic in iptable.go to add/drop iptables rule `iptables -A INPUT -i eth0 -p tcp --dport 51678 -j DROP`


### Testing
<!-- How was this tested? -->
Added unit test. Built the rpm and verified the rule is added by default, and not added when opted out.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Block offhost access to agent's introspection port by default. Configurable via env `ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS`.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
