### PR TITLE
Add bind mount for agent

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -462,7 +462,7 @@ func getCapabilityExecBinds(pathPredicate func(path string, predicate func(fileI
 
 	binds := []string{}
 
-	// bind mount the entire /deps/exec/bin folder for higher flexibility
+	// bind mount the entire /host/dependency/path/exec/bin folder for higher flexibility
 	// minimal change required to add other ssm binaries as dependency in the future (just need to be placed inside the bin directory)
 	hostCapabilityExecBinDir := filepath.Join(hostCapabilityExecResourcesDir, hostBinRelativePath)
 	if exists, err := pathPredicate(hostCapabilityExecBinDir, isDir); err == nil && exists {

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -443,7 +443,7 @@ func getDockerPluginDirBinds() []string {
 }
 
 // take pathPredicate as an argument for unit testing
-func getCapabilityExecBinds(pathPredicate func(path string, predicate func(fileInfo os.FileInfo) bool) (bool, error)) []string {
+func getCapabilityExecBinds(pathPredicate func(string, func(os.FileInfo) bool) (bool, error)) []string {
 	hostResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
 	containerResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
 
@@ -465,7 +465,7 @@ func getCapabilityExecBinds(pathPredicate func(path string, predicate func(fileI
 	return binds
 }
 
-func pathExistsAndValid(path string, predicate func(fileInfo os.FileInfo) bool) (bool, error) {
+func pathExistsAndValid(path string, predicate func(os.FileInfo) bool) (bool, error) {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -186,6 +186,12 @@ func TestRemoveExistingAgentContainer(t *testing.T) {
 func TestStartAgentNoEnvFile(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	isPathValid = func(path string, isDir bool) bool {
+		return false
+	}
+	defer func() {
+		isPathValid = defaultIsPathValid
+	}()
 
 	containerID := "container id"
 
@@ -316,6 +322,12 @@ func expectKey(key string, input map[string]struct{}, t *testing.T) {
 func TestStartAgentEnvFile(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	isPathValid = func(path string, isDir bool) bool {
+		return false
+	}
+	defer func() {
+		isPathValid = defaultIsPathValid
+	}()
 
 	envFile := "\nAGENT_TEST_VAR=val\nAGENT_TEST_VAR2=val2\n"
 	containerID := "container id"
@@ -354,6 +366,12 @@ func TestStartAgentEnvFile(t *testing.T) {
 func TestStartAgentWithGPUConfig(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	isPathValid = func(path string, isDir bool) bool {
+		return false
+	}
+	defer func() {
+		isPathValid = defaultIsPathValid
+	}()
 
 	envFile := "\nECS_ENABLE_GPU_SUPPORT=true\n"
 	containerID := "container id"
@@ -407,6 +425,12 @@ func TestStartAgentWithGPUConfig(t *testing.T) {
 func TestStartAgentWithGPUConfigNoDevices(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	isPathValid = func(path string, isDir bool) bool {
+		return false
+	}
+	defer func() {
+		isPathValid = defaultIsPathValid
+	}()
 
 	envFile := "\nECS_ENABLE_GPU_SUPPORT=true\n"
 	containerID := "container id"


### PR DESCRIPTION
### Summary

This is part of the change for ecs-agent to detect if an EC2 instance is `exec-enabled`, in other words, if the instance has the `exec` capability. Related change in [amazon-ecs-agent](https://github.com/aws/amazon-ecs-agent):
(add link to pr in ecs-agent)

Update ecs-init to add bind mounts to the ecs-agent containter for exec-for-ECS capability detection. For an EC2 instance to be considered as `exec-enabed`, the instance needs to have these resources required by SSM:

* SSM agent binaries
* ~~SSM agent configuration files~~ (not validated for now)
* certs files for SSM agent

### Implementation details

For now, we only want to make sure all resources required by SSM (binaries, certs) exist. Since capabilities are stamped by ecs-agent, we need to provide a mechanism for the ecs-agent container to inspect the file system on host instance. To do this, we add bind mounts from the host instance to the ecs-agent container to check if all the following files exist:

```
/host/path/to/ecs-exec-dep
|-- bin
    |-- amazon-ssm-agent
    |-- ssm-session-worker

/host/path/to/certs
|-- tls-ca-bundle.pem
```

these get bind mounted to the ecs-agent container as:

```
/capabilities/exec/
|-- bin
    |-- amazon-ssm-agent
    |-- ssm-session-worker
|-- certs
    |-- tls-ca-bundle.pem
```

One detail is to only create a bind mount if the source file/directory exists on host, we do **not** want to create an empty directory (with `sudo`) on host instance with docker. If the require file/directory does not exist on the instance, we want the ecs-agent to know that these resources do not exist, so the `exec` capability will not be added.

### Testing

Manual test:

1. `sudo systemctl start ecs`
2. when all dependencies exist, inspect `amazon-ecs-agent:latest` container to check if all corresponding binds in `HostConfig` and mounts are added
3. remove one of the dependencies, `sudo systemctl start ecs`
4. inspect `amazon-ecs-agent:latest` container to check the corresponding binds and mounts are no longer added

New tests cover the changes: yes

* `TestGetCapabilityExecBinds`
* `TestPathExistsAndValid`
* `TestIsDir`
* `TestIsFile`

### Description for the changelog

add bind mounts from SSM dependency (files/directories) on host to ecs-agent container for exec capability detection 

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
