### PR TITLE
add ExecAgent logs bind mount to agent

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -117,6 +117,8 @@ const (
 	capabilityExecHostCertsDir               = "/etc/pki/ca-trust/extracted/pem"
 	capabilityExecContainerCertsRelativePath = "certs"
 	capabilityExecRequiredCert               = "tls-ca-bundle.pem"
+
+	execAgentLogRelativePath = "/exec"
 )
 
 var pluginDirs = []string{
@@ -388,6 +390,7 @@ func (c *Client) getHostConfig(envVarsFromFiles map[string]string) *godocker.Hos
 		config.CgroupMountpoint() + ":" + DefaultCgroupMountpoint,
 		// bind mount instance config dir
 		config.InstanceConfigDirectory() + ":" + config.InstanceConfigDirectory(),
+		filepath.Join(config.LogDirectory(), execAgentLogRelativePath) + ":" + filepath.Join(logDir, execAgentLogRelativePath),
 	}
 
 	// for al, al2 add host ssl cert directory mounts

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -33,8 +33,8 @@ import (
 const (
 	testTempDirPrefix = "init-docker-test-"
 
-	expectedAgentBindsUnspecifiedPlatform = 19
-	expectedAgentBindsSuseUbuntuPlatform  = 17
+	expectedAgentBindsUnspecifiedPlatform = 20
+	expectedAgentBindsSuseUbuntuPlatform  = 18
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -279,6 +279,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+":ro", binds, t)
 	expectKey(iptablesAltDir+":"+iptablesAltDir+":ro", binds, t)
 	expectKey(iptablesLegacyDir+":"+iptablesLegacyDir+":ro", binds, t)
+	expectKey(config.LogDirectory()+"/exec:/log/exec", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
ECS Agent cleans up the exec agent logs when exec enabled tasks are cleaned up. 
In order for ECS agent to remove the logs, making them available through this bind mount. 
Note: Since this is done from init, check for 'exec capability' is not done before bind mounting the log path. 


### Implementation details
bind mount `/var/log/ecs/exec` from host to `/log/exec` in agent container  

### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
N/A


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
