### PR TITLE
fixing gocyclo break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ ubuntu-trusty:
 get-deps:
 	go get golang.org/x/tools/cover
 	go get golang.org/x/tools/cmd/cover
-	go get github.com/fzipp/gocyclo
+	go get github.com/fzipp/gocyclo/cmd/gocyclo
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/golang/mock/mockgen
 	go get honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
`gocyclo` [changed](https://github.com/fzipp/gocyclo/commit/48b28985d52fd8113eb410d9bb09d17d977e7e9f) its `go get` path and this broke us. Changing it to fix the static check failures. 


### Testing
Travis passes

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
