### PR TITLE
update capability name, add config to agent binds

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -109,16 +109,14 @@ const (
 	iptablesUsrLib64Dir = "/usr/lib64"
 
 	hostCapabilitiesResourcesRootDir      = "/var/lib/ecs/deps"
-	containerCapabilitiesResourcesRootDir = "/capabilities"
+	containerCapabilitiesResourcesRootDir = "/managed-agents"
 
-	capabilityExecName                        = "execute-command"
-	capabilityExecHostBinRelativePath         = "bin"
-	capabilityExecContainerBinRelativePath    = "bin"
-	capabilityExecHostConfigRelativePath      = "config"
-	capabilityExecContainerConfigRelativePath = "config"
-	capabilityExecHostCertsDir                = "/etc/pki/ca-trust/extracted/pem"
-	capabilityExecContainerCertsRelativePath  = "certs"
-	capabilityExecRequiredCert                = "tls-ca-bundle.pem"
+	capabilityExecName               = "execute-command"
+	capabilityExecBinRelativePath    = "bin"
+	capabilityExecConfigRelativePath = "config"
+	capabilityExecCertsRelativePath  = "certs"
+	capabilityExecHostCertsDir       = "/etc/pki/ca-trust/extracted/pem"
+	capabilityExecRequiredCert       = "tls-ca-bundle.pem"
 
 	execAgentLogRelativePath = "/exec"
 )
@@ -456,25 +454,25 @@ func getCapabilityExecBinds() []string {
 	var binds []string
 
 	// bind mount the entire /host/dependency/path/execute-command/bin folder
-	hostBinDir := filepath.Join(hostResourcesDir, capabilityExecHostBinRelativePath)
+	hostBinDir := filepath.Join(hostResourcesDir, capabilityExecBinRelativePath)
 	if isPathValid(hostBinDir, true) {
 		binds = append(binds,
-			hostBinDir+":"+filepath.Join(containerResourcesDir, capabilityExecContainerBinRelativePath)+readOnly)
+			hostBinDir+":"+filepath.Join(containerResourcesDir, capabilityExecBinRelativePath)+readOnly)
 	}
 
 	// bind mount the entire /host/dependency/path/execute-command/config folder
 	// in read-write mode to allow ecs-agent to write config files to host file system
-	hostConfigDir := filepath.Join(hostResourcesDir, capabilityExecHostConfigRelativePath)
+	hostConfigDir := filepath.Join(hostResourcesDir, capabilityExecConfigRelativePath)
 	if isPathValid(hostConfigDir, true) {
 		binds = append(binds,
-			hostConfigDir+":"+filepath.Join(containerResourcesDir, capabilityExecContainerConfigRelativePath))
+			hostConfigDir+":"+filepath.Join(containerResourcesDir, capabilityExecConfigRelativePath))
 	}
 
 	// bind mount this specific cert file for now
 	hostCert := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
 	if isPathValid(hostCert, false) {
 		binds = append(binds,
-			hostCert+":"+filepath.Join(containerResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)+readOnly)
+			hostCert+":"+filepath.Join(containerResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)+readOnly)
 	}
 
 	return binds

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -108,15 +108,15 @@ const (
 	iptablesLib64Dir    = "/lib64"
 	iptablesUsrLib64Dir = "/usr/lib64"
 
-	hostCapabilitiesResourcesRootDir      = "/var/lib/ecs/deps"
-	containerCapabilitiesResourcesRootDir = "/managed-agents"
+	hostResourcesRootDir      = "/var/lib/ecs/deps"
+	containerResourcesRootDir = "/managed-agents"
 
-	capabilityExecName               = "execute-command"
-	capabilityExecBinRelativePath    = "bin"
-	capabilityExecConfigRelativePath = "config"
-	capabilityExecCertsRelativePath  = "certs"
-	capabilityExecHostCertsDir       = "/etc/pki/ca-trust/extracted/pem"
-	capabilityExecRequiredCert       = "tls-ca-bundle.pem"
+	execCapabilityName     = "execute-command"
+	execBinRelativePath    = "bin"
+	execConfigRelativePath = "config"
+	execCertsRelativePath  = "certs"
+	execHostCertsDir       = "/etc/pki/ca-trust/extracted/pem"
+	execRequiredCert       = "tls-ca-bundle.pem"
 
 	execAgentLogRelativePath = "/exec"
 )
@@ -448,31 +448,31 @@ func getDockerPluginDirBinds() []string {
 }
 
 func getCapabilityExecBinds() []string {
-	hostResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
-	containerResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
+	hostResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
+	containerResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
 	var binds []string
 
 	// bind mount the entire /host/dependency/path/execute-command/bin folder
-	hostBinDir := filepath.Join(hostResourcesDir, capabilityExecBinRelativePath)
+	hostBinDir := filepath.Join(hostResourcesDir, execBinRelativePath)
 	if isPathValid(hostBinDir, true) {
 		binds = append(binds,
-			hostBinDir+":"+filepath.Join(containerResourcesDir, capabilityExecBinRelativePath)+readOnly)
+			hostBinDir+":"+filepath.Join(containerResourcesDir, execBinRelativePath)+readOnly)
 	}
 
 	// bind mount the entire /host/dependency/path/execute-command/config folder
 	// in read-write mode to allow ecs-agent to write config files to host file system
-	hostConfigDir := filepath.Join(hostResourcesDir, capabilityExecConfigRelativePath)
+	hostConfigDir := filepath.Join(hostResourcesDir, execConfigRelativePath)
 	if isPathValid(hostConfigDir, true) {
 		binds = append(binds,
-			hostConfigDir+":"+filepath.Join(containerResourcesDir, capabilityExecConfigRelativePath))
+			hostConfigDir+":"+filepath.Join(containerResourcesDir, execConfigRelativePath))
 	}
 
 	// bind mount this specific cert file for now
-	hostCert := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
+	hostCert := filepath.Join(execHostCertsDir, execRequiredCert)
 	if isPathValid(hostCert, false) {
 		binds = append(binds,
-			hostCert+":"+filepath.Join(containerResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)+readOnly)
+			hostCert+":"+filepath.Join(containerResourcesDir, execCertsRelativePath, execRequiredCert)+readOnly)
 	}
 
 	return binds

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -108,15 +108,17 @@ const (
 	iptablesLib64Dir    = "/lib64"
 	iptablesUsrLib64Dir = "/usr/lib64"
 
-	hostCapabilitiesResourcesRootDir      = "/var/lib/ecs"
+	hostCapabilitiesResourcesRootDir      = "/var/lib/ecs/deps"
 	containerCapabilitiesResourcesRootDir = "/capabilities"
 
-	capabilityExecName                       = "exec"
-	capabilityExecHostBinRelativePath        = "ssm-agent/linux_amd64"
-	capabilityExecContainerBinRelativePath   = "bin"
-	capabilityExecHostCertsDir               = "/etc/pki/ca-trust/extracted/pem"
-	capabilityExecContainerCertsRelativePath = "certs"
-	capabilityExecRequiredCert               = "tls-ca-bundle.pem"
+	capabilityExecName                        = "execute-command"
+	capabilityExecHostBinRelativePath         = "bin"
+	capabilityExecContainerBinRelativePath    = "bin"
+	capabilityExecHostConfigRelativePath      = "config"
+	capabilityExecContainerConfigRelativePath = "config"
+	capabilityExecHostCertsDir                = "/etc/pki/ca-trust/extracted/pem"
+	capabilityExecContainerCertsRelativePath  = "certs"
+	capabilityExecRequiredCert                = "tls-ca-bundle.pem"
 
 	execAgentLogRelativePath = "/exec"
 )
@@ -453,17 +455,26 @@ func getCapabilityExecBinds() []string {
 
 	var binds []string
 
-	// bind mount the entire /host/dependency/path/exec/bin folder for higher flexibility
-	// minimal change required to add other ssm binaries as dependency in the future (just need to be placed inside the bin directory)
+	// bind mount the entire /host/dependency/path/execute-command/bin folder
 	hostBinDir := filepath.Join(hostResourcesDir, capabilityExecHostBinRelativePath)
 	if isPathValid(hostBinDir, true) {
-		binds = append(binds, hostBinDir+":"+filepath.Join(containerResourcesDir, capabilityExecContainerBinRelativePath)+readOnly)
+		binds = append(binds,
+			hostBinDir+":"+filepath.Join(containerResourcesDir, capabilityExecContainerBinRelativePath)+readOnly)
 	}
 
-	// bind mount this specific cert file for now, CertsDir and CertsFile might be changed to be configurable in the future
+	// bind mount the entire /host/dependency/path/execute-command/config folder
+	// in read-write mode to allow ecs-agent to write config files to host file system
+	hostConfigDir := filepath.Join(hostResourcesDir, capabilityExecHostConfigRelativePath)
+	if isPathValid(hostConfigDir, true) {
+		binds = append(binds,
+			hostConfigDir+":"+filepath.Join(containerResourcesDir, capabilityExecContainerConfigRelativePath))
+	}
+
+	// bind mount this specific cert file for now
 	hostCert := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
 	if isPathValid(hostCert, false) {
-		binds = append(binds, hostCert+":"+filepath.Join(containerResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)+readOnly)
+		binds = append(binds,
+			hostCert+":"+filepath.Join(containerResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)+readOnly)
 	}
 
 	return binds

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -793,16 +793,16 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
 
 	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerBinRelativePath)
+	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecBinRelativePath)
+	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecBinRelativePath)
 
 	// config
-	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostConfigRelativePath)
-	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerConfigRelativePath)
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
 
 	// certs
 	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)
+	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)
 
 	expectedExecBinds := []string{
 		hostBinDir + ":" + containerBinDir + readOnly,
@@ -848,16 +848,16 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
 
 	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerBinRelativePath)
+	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecBinRelativePath)
+	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecBinRelativePath)
 
 	// config
-	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostConfigRelativePath)
-	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerConfigRelativePath)
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
 
 	// certs
 	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)
+	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)
 
 	testCases := []struct {
 		name            string

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -789,7 +789,27 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	isPathValid = func(path string, isDir bool) bool {
 		return true
 	}
-	expectedAgentBinds += 2
+	hostCapabilityExecResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
+	containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
+
+	// binaries
+	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostBinRelativePath)
+	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerBinRelativePath)
+
+	// config
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerConfigRelativePath)
+
+	// certs
+	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
+	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)
+
+	expectedExecBinds := []string{
+		hostBinDir + ":" + containerBinDir + readOnly,
+		hostConfigDir + ":" + containerConfigDir,
+		hostCertsFile + ":" + containerCertsFile + readOnly,
+	}
+	expectedAgentBinds += len(expectedExecBinds)
 	defer func() {
 		expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
 		isPathValid = defaultIsPathValid
@@ -804,34 +824,7 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 		validateCommonCreateContainerOptions(opts, t)
 
 		// verify that exec binds are added
-		hostCapabilityExecResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
-		containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
-
-		// binaries
-		hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostBinRelativePath)
-		containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerBinRelativePath)
-
-		// certs
-		hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
-		containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)
-
-		expectedBinds := []string{
-			hostBinDir + ":" + containerBinDir + readOnly,
-			hostCertsFile + ":" + containerCertsFile + readOnly,
-		}
-
-		for _, expectedBind := range expectedBinds {
-			added := false
-			agentBinds := opts.HostConfig.Binds
-			for _, bind := range agentBinds {
-				if bind == expectedBind {
-					added = true
-					break
-				}
-			}
-
-			assert.True(t, added, "%v should be added to HostConfig.Binds", expectedBind)
-		}
+		assert.Subset(t, opts.HostConfig.Binds, expectedExecBinds)
 	}).Return(&godocker.Container{
 		ID: containerID,
 	}, nil)
@@ -858,6 +851,10 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostBinRelativePath)
 	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerBinRelativePath)
 
+	// config
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecHostConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerConfigRelativePath)
+
 	// certs
 	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
 	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecContainerCertsRelativePath, capabilityExecRequiredCert)
@@ -874,6 +871,7 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			},
 			expectedBinds: []string{
 				hostBinDir + ":" + containerBinDir + readOnly,
+				hostConfigDir + ":" + containerConfigDir,
 				hostCertsFile + ":" + containerCertsFile + readOnly,
 			},
 		},

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -789,20 +789,20 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	isPathValid = func(path string, isDir bool) bool {
 		return true
 	}
-	hostCapabilityExecResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
-	containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
+	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
+	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
 	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecBinRelativePath)
+	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
+	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
 
 	// config
-	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
-	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
 	// certs
-	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)
+	hostCertsFile := filepath.Join(execHostCertsDir, execRequiredCert)
+	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath, execRequiredCert)
 
 	expectedExecBinds := []string{
 		hostBinDir + ":" + containerBinDir + readOnly,
@@ -844,20 +844,20 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	defer func() {
 		isPathValid = defaultIsPathValid
 	}()
-	hostCapabilityExecResourcesDir := filepath.Join(hostCapabilitiesResourcesRootDir, capabilityExecName)
-	containerCapabilityExecResourcesDir := filepath.Join(containerCapabilitiesResourcesRootDir, capabilityExecName)
+	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
+	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
 	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecBinRelativePath)
+	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
+	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
 
 	// config
-	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
-	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecConfigRelativePath)
+	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
+	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
 	// certs
-	hostCertsFile := filepath.Join(capabilityExecHostCertsDir, capabilityExecRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, capabilityExecCertsRelativePath, capabilityExecRequiredCert)
+	hostCertsFile := filepath.Join(execHostCertsDir, execRequiredCert)
+	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath, execRequiredCert)
 
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
### Summary

this change updates bind mounts to `ecs-agent` from `ecs-init` to use the constants defined in https://github.com/aws/amazon-ecs-agent/pull/2687.

### Implementation details

update capability name to match the latest decision spec. add config folder as an a agent bind to allow ecs-agent to write (ssm configuration files) to host file system

### Testing

manual test include starting the `ecs-agent` container and inspecting, automated unit test is also added

New tests cover the changes: no

existing tests updated:

* TestStartAgentWithExecBinds
* TestGetCapabilityExecBinds

### Description for the changelog

update capability ecs-exec name, add config to agent binds

### Licensing

This contribution is under the terms of the Apache 2.0 License: yes
