### PR TITLE
Update bind mount for certs folder

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -115,8 +115,6 @@ const (
 	execBinRelativePath    = "bin"
 	execConfigRelativePath = "config"
 	execCertsRelativePath  = "certs"
-	execHostCertsDir       = "/etc/pki/ca-trust/extracted/pem"
-	execRequiredCert       = "tls-ca-bundle.pem"
 
 	execAgentLogRelativePath = "/exec"
 )
@@ -468,11 +466,11 @@ func getCapabilityExecBinds() []string {
 			hostConfigDir+":"+filepath.Join(containerResourcesDir, execConfigRelativePath))
 	}
 
-	// bind mount this specific cert file for now
-	hostCert := filepath.Join(execHostCertsDir, execRequiredCert)
-	if isPathValid(hostCert, false) {
+	// bind mount the entire /host/dependency/path/execute-command/certs folder
+	hostCertsDir := filepath.Join(hostResourcesDir, execCertsRelativePath)
+	if isPathValid(hostCertsDir, true) {
 		binds = append(binds,
-			hostCert+":"+filepath.Join(containerResourcesDir, execCertsRelativePath, execRequiredCert)+readOnly)
+			hostCertsDir+":"+filepath.Join(containerResourcesDir, execCertsRelativePath)+readOnly)
 	}
 
 	return binds

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -801,13 +801,13 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
 	// certs
-	hostCertsFile := filepath.Join(execHostCertsDir, execRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath, execRequiredCert)
+	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
+	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
 
 	expectedExecBinds := []string{
 		hostBinDir + ":" + containerBinDir + readOnly,
 		hostConfigDir + ":" + containerConfigDir,
-		hostCertsFile + ":" + containerCertsFile + readOnly,
+		hostCertsDir + ":" + containerCertsDir + readOnly,
 	}
 	expectedAgentBinds += len(expectedExecBinds)
 	defer func() {
@@ -856,8 +856,8 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
 	// certs
-	hostCertsFile := filepath.Join(execHostCertsDir, execRequiredCert)
-	containerCertsFile := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath, execRequiredCert)
+	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
+	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
 
 	testCases := []struct {
 		name            string
@@ -872,7 +872,7 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			expectedBinds: []string{
 				hostBinDir + ":" + containerBinDir + readOnly,
 				hostConfigDir + ":" + containerConfigDir,
-				hostCertsFile + ":" + containerCertsFile + readOnly,
+				hostCertsDir + ":" + containerCertsDir + readOnly,
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
change init to bind mount the certs folder instead of bind mount the specific cert file

### Implementation details
<!-- How are the changes implemented?
If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Change from binding mount a specific file to binding mount a cert directory. 
Remove previous hostCertsFile and containerCertsFile.
Add new hostCertsDir and containerCertsDir. 

### Testing
<!-- How was this tested? -->
modify the existing tests

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
