### PR TITLE
remove iptables rule that drops packets to port 51678 unconditionally on ecs service stop.

### DIFF
--- a/ecs-init/exec/iptables/iptables.go
+++ b/ecs-init/exec/iptables/iptables.go
@@ -113,11 +113,9 @@ func (route *NetfilterRoute) Remove() error {
 		}
 	}
 
-	if !allowOffhostIntrospection() {
-		introspectionInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getBlockIntrospectionOffhostAccessInputChainArgs)
-		if introspectionInputError != nil {
-			introspectionInputError = fmt.Errorf("error removing input chain entry: %v", introspectionInputError)
-		}
+	introspectionInputError = route.modifyNetfilterEntry(iptablesTableFilter, iptablesDelete, getBlockIntrospectionOffhostAccessInputChainArgs)
+	if introspectionInputError != nil {
+		introspectionInputError = fmt.Errorf("error removing input chain entry: %v", introspectionInputError)
 	}
 
 	outputErr := route.modifyNetfilterEntry(iptablesTableNat, iptablesDelete, getOutputChainArgs)

--- a/ecs-init/exec/iptables/iptables_test.go
+++ b/ecs-init/exec/iptables/iptables_test.go
@@ -307,6 +307,9 @@ func TestRemoveAllowIntrospectionOffhostAccess(t *testing.T) {
 			expectedArgs("filter", "-D", "INPUT", localhostTrafficFilterInputRouteArgs)).Return(mockCmd),
 		mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil),
 		mockExec.EXPECT().Command(iptablesExecutable,
+			expectedArgs("filter", "-D", "INPUT", blockIntrospectionOffhostAccessInputRouteArgs)).Return(mockCmd),
+		mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil),
+		mockExec.EXPECT().Command(iptablesExecutable,
 			expectedArgs("nat", "-D", "OUTPUT", outputRouteArgs)).Return(mockCmd),
 		mockCmd.EXPECT().CombinedOutput().Return([]byte{0}, nil),
 	)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This pull request fix https://github.com/aws/amazon-ecs-init/issues/360, 
Currently, iptables rule that drops packets to port 51678 is removed on ecs service stop only when ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS=false(default). When customer changing ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS from false to true with the consecutive systemctl restart ecs doesn't remove the iptables rule which drops packets to port 51678.

This PR remove iptables rule that drops packets to port 51678  unconditionally on ecs service stop to avoid the case above.

### Implementation details
<!-- How are the changes implemented?
If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
remove the conditional check, when customer change the ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS=False to True, stop/restart the iptable rule will be removed. 

### Testing
<!-- How was this tested? -->

modifies current test case. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
