### PR TITLE
remove ifExists check for config folder

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -460,11 +460,10 @@ func getCapabilityExecBinds() []string {
 
 	// bind mount the entire /host/dependency/path/execute-command/config folder
 	// in read-write mode to allow ecs-agent to write config files to host file system
+	// (docker will) create the config folder if it does not exist
 	hostConfigDir := filepath.Join(hostResourcesDir, execConfigRelativePath)
-	if isPathValid(hostConfigDir, true) {
-		binds = append(binds,
-			hostConfigDir+":"+filepath.Join(containerResourcesDir, execConfigRelativePath))
-	}
+	binds = append(binds,
+		hostConfigDir+":"+filepath.Join(containerResourcesDir, execConfigRelativePath))
 
 	// bind mount the entire /host/dependency/path/execute-command/certs folder
 	hostCertsDir := filepath.Join(hostResourcesDir, execCertsRelativePath)

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	testTempDirPrefix = "init-docker-test-"
 
-	expectedAgentBindsUnspecifiedPlatform = 20
+	expectedAgentBindsUnspecifiedPlatform = 21
 	expectedAgentBindsSuseUbuntuPlatform  = 18
 )
 
@@ -806,10 +806,12 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 
 	expectedExecBinds := []string{
 		hostBinDir + ":" + containerBinDir + readOnly,
-		hostConfigDir + ":" + containerConfigDir,
 		hostCertsDir + ":" + containerCertsDir + readOnly,
 	}
 	expectedAgentBinds += len(expectedExecBinds)
+
+	// bind mount for the config folder is already included in expectedAgentBinds since it's always added
+	expectedExecBinds = append(expectedExecBinds, hostConfigDir+":"+containerConfigDir)
 	defer func() {
 		expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
 		isPathValid = defaultIsPathValid
@@ -882,6 +884,7 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			},
 			expectedBinds: []string{
 				hostBinDir + ":" + containerBinDir + readOnly,
+				hostConfigDir + ":" + containerConfigDir,
 			},
 		},
 		{
@@ -889,7 +892,9 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			testIsPathValid: func(path string, isDir bool) bool {
 				return false
 			},
-			expectedBinds: nil,
+			expectedBinds: []string{
+				hostConfigDir + ":" + containerConfigDir,
+			},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
add the logic bind mount the entire /host/dependency/path/execute-command/config folder
in read-write mode to allow ecs-agent to write config files to host file system 
docker will create the config folder if it does not exist

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
add the hostConfigDir bind mount unconditionally to add the case that if config dir when its not exists, we will create one.

### Testing
<!-- How was this tested? -->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
