### PR TITLE
sync aws-sdk-go version

### DIFF
--- a/ecs-init/Gopkg.toml
+++ b/ecs-init/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.35.37"
+  version = "v1.36.0"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The version that was pulled in by `dep ensure` was actually 1.36.0 (the latest tagged version on that date). The version was originally malformed in the Gopkg.toml file.

### Implementation details
I updated the Gopkg.toml file, ran `make get-dep` and `dep ensure` and there were no updates generated.

### Testing
Ran `make gogenerate` then `make test` locally

New tests cover the changes: no

### Description for the changelog
Sync Gopkg.toml with Gopkg.lock

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
