### PR TITLE
Add support for running in non-EC2 environment

### DIFF
--- a/ecs-init/cache/dependencies.go
+++ b/ecs-init/cache/dependencies.go
@@ -141,6 +141,13 @@ type instanceMetadata interface {
 	Region() (string, error)
 }
 
+type blackholeInstanceMetadata struct {
+}
+
+func (b *blackholeInstanceMetadata) Region() (string, error) {
+	return "", errors.New("blackholed")
+}
+
 // standardFS delegates to the package-level functions
 type standardFS struct{}
 

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -87,6 +87,12 @@ const (
 
 	// DockerHostEnvVar is the environment variable that specifies the location of the Docker daemon socket.
 	DockerHostEnvVar = "DOCKER_HOST"
+
+	// ExternalEnvVar is the environment variable for specifying whether we are running in external (non-EC2) environment.
+	ExternalEnvVar = "ECS_EXTERNAL"
+
+	// DefaultRegionEnvVar is the environment variable for specifying the default AWS region to use.
+	DefaultRegionEnvVar = "AWS_DEFAULT_REGION"
 )
 
 // partitionBucketRegion provides the "partitional" bucket region
@@ -286,6 +292,12 @@ func InstanceConfigFile() string {
 // recommended and may be removed in future versions of amazon-ecs-init.
 func RunPrivileged() bool {
 	envVar := os.Getenv("ECS_AGENT_RUN_PRIVILEGED")
+	return envVar == "true"
+}
+
+// RunningInExternal returns whether we are running in external (non-EC2) environment.
+func RunningInExternal() bool {
+	envVar := os.Getenv(ExternalEnvVar)
 	return envVar == "true"
 }
 

--- a/ecs-init/config/common_test.go
+++ b/ecs-init/config/common_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDockerUnixSocketWithoutDockerHost(t *testing.T) {
@@ -244,4 +246,10 @@ func TestAgentPrivilegedNotConfigured(t *testing.T) {
 			t.Errorf("Agent was expected to be running without privileged mode. Testcase (%s)", test)
 		}
 	}
+}
+
+func TestAgentRunningInExternal(t *testing.T) {
+	os.Setenv(ExternalEnvVar, "true")
+	defer os.Unsetenv(ExternalEnvVar)
+	assert.True(t, RunningInExternal())
 }

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -98,6 +98,10 @@ const (
 	iptablesAltDir = "/etc/alternatives"
 	// legacyDir holds the location of legacy iptables
 	iptablesLegacyDir = "/usr/sbin"
+	// externalEnvCredsHostDir specifies the location of the credentials on host when running in external environment.
+	externalEnvCredsHostDir = "/root/.aws"
+	// externalEnvCredsContainerDir specifies the location of the credentials that will be mounted in agent container.
+	externalEnvCredsContainerDir = "/rotatingcreds"
 
 	// the following libDirs  specify the location of shared libraries on the
 	// host and in the Agent container required for the execution of the iptables
@@ -276,6 +280,10 @@ func (c *Client) getContainerConfig(envVarsFromFiles map[string]string) *godocke
 	for key, val := range envVarsFromFiles {
 		envVariables[key] = val
 	}
+	if config.RunningInExternal() {
+		// Task networking is not supported when not running on EC2. Explicitly disable since it's enabled by default.
+		envVariables["ECS_ENABLE_TASK_ENI"] = "false"
+	}
 
 	var env []string
 	for envKey, envValue := range envVariables {
@@ -381,6 +389,11 @@ func (c *Client) getHostConfig(envVarsFromFiles map[string]string) *godocker.Hos
 	if pkiDir := config.HostPKIDirPath(); pkiDir != "" {
 		certsPath := pkiDir + ":" + pkiDir + readOnly
 		binds = append(binds, certsPath)
+	}
+
+	if config.RunningInExternal() {
+		credsPath := externalEnvCredsHostDir + ":" + externalEnvCredsContainerDir + readOnly
+		binds = append(binds, credsPath)
 	}
 
 	for key, val := range c.LoadEnvVars() {

--- a/ecs-init/docker/docker_unspecified.go
+++ b/ecs-init/docker/docker_unspecified.go
@@ -46,12 +46,20 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 
+	var caps []string
+	if !config.RunningInExternal() {
+		// CapNetAdmin and CapSysAdmin are needed for running task in awsvpc network mode.
+		// This network mode is (at least currently) not supported in external environment,
+		// hence not adding them in that case.
+		caps = []string{CapNetAdmin, CapSysAdmin}
+	}
+
 	hostConfig := &godocker.HostConfig{
 		LogConfig:   logConfig,
 		Binds:       binds,
 		NetworkMode: networkMode,
 		UsernsMode:  usernsMode,
-		CapAdd:      []string{CapNetAdmin, CapSysAdmin},
+		CapAdd:      caps,
 		Init:        true,
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add support for running in external (non-EC2) environment. This includes changes to:
1. Detect whether we are running in external env by checking env "ECS_EXTERNAL". When packing the ecs init rpm, ecs init will load an ecs.config file as an env file that sets this to true;
2. When detecting that we are running in external env, add the following behavior changes:
   - Disable ec2 metadata call;
   - Add host credentials bind mount;
   - Disable task networking.

This pull request only make change to code but not packaging, just to allow the code to work with non-EC2 environment. Packaging changes will be added separately.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
* `cache`: disable ec2 metadata call for agent tar downloader when running in external;
* `config`: add helper to detect whether we run in external env;  
* `docker`: add host creds bind mount, disable task networking.

### Testing
<!-- How was this tested? -->
Added unit test. Manually tested by building the rpm and run it in a centos:7 vagrant image, verified agent is started correctly.

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
