### PR TITLE
Prevent restart on exit code 5

### DIFF
--- a/ecs-init/ecs-init.go
+++ b/ecs-init/ecs-init.go
@@ -48,7 +48,7 @@ func main() {
 
 	logger, err := log.LoggerFromConfigAsString(config.Logger())
 	if err != nil {
-		die(err)
+		die(err, engine.DefaultInitErrorExitCode)
 	}
 	log.ReplaceLogger(logger)
 
@@ -62,7 +62,7 @@ func main() {
 
 	init, err := engine.New()
 	if err != nil {
-		die(err)
+		die(err, engine.DefaultInitErrorExitCode)
 	}
 	log.Info(args[0])
 	actions := actions(init)
@@ -72,8 +72,12 @@ func main() {
 		os.Exit(1)
 	}
 	err = action.function()
+
 	if err != nil {
-		die(err)
+		if err, ok := err.(*engine.TerminalError); ok {
+			die(err, engine.TerminalFailureAgentExitCode)
+		}
+		die(err, engine.DefaultInitErrorExitCode)
 	}
 }
 
@@ -123,8 +127,8 @@ func usage(actions map[string]action) {
 	fmt.Println("")
 }
 
-func die(err error) {
+func die(err error, exitCode int) {
 	log.Error(err.Error())
 	log.Flush()
-	os.Exit(-1)
+	os.Exit(exitCode)
 }

--- a/ecs-init/engine/engine.go
+++ b/ecs-init/engine/engine.go
@@ -35,7 +35,8 @@ import (
 const (
 	terminalSuccessAgentExitCode  = 0
 	containerFailureAgentExitCode = 2
-	terminalFailureAgentExitCode  = 5
+	TerminalFailureAgentExitCode  = 5
+	DefaultInitErrorExitCode      = -1
 	upgradeAgentExitCode          = 42
 	serviceStartMinRetryTime      = time.Millisecond * 500
 	serviceStartMaxRetryTime      = time.Second * 15
@@ -53,6 +54,15 @@ type Engine struct {
 	credentialsProxyRoute    credentialsProxyRoute
 	ipv6RouterAdvertisements ipv6RouterAdvertisements
 	nvidiaGPUManager         gpu.GPUManager
+}
+
+type TerminalError struct {
+	err      string
+	exitCode int
+}
+
+func (e *TerminalError) Error() string {
+	return fmt.Sprintf("%s: %d", e.err, e.exitCode)
 }
 
 // New creates an instance of Engine
@@ -228,8 +238,11 @@ func (e *Engine) StartSupervised() error {
 			log.Infof("Captured the last %s lines of the agent container logs====>\n", failedContainerLogWindowSize)
 			log.Info(e.docker.GetContainerLogTail(failedContainerLogWindowSize))
 			log.Infof("<====end %s lines of the failed agent container logs\n", failedContainerLogWindowSize)
-		case terminalFailureAgentExitCode:
-			return errors.New("agent exited with terminal exit code")
+		case TerminalFailureAgentExitCode:
+			return &TerminalError{
+				err:      "agent exited with terminal exit code",
+				exitCode: TerminalFailureAgentExitCode,
+			}
 		case terminalSuccessAgentExitCode:
 			return nil
 		}

--- a/ecs-init/engine/engine_test.go
+++ b/ecs-init/engine/engine_test.go
@@ -260,15 +260,21 @@ func TestStartSupervisedExitsWhenTerminalFailure(t *testing.T) {
 		mockDocker.EXPECT().RemoveExistingAgentContainer(),
 		mockDocker.EXPECT().StartAgent().Return(1, nil),
 		mockDocker.EXPECT().RemoveExistingAgentContainer(),
-		mockDocker.EXPECT().StartAgent().Return(terminalFailureAgentExitCode, nil),
+		mockDocker.EXPECT().StartAgent().Return(TerminalFailureAgentExitCode, nil),
 	)
 
 	engine := &Engine{
 		docker: mockDocker,
 	}
 	err := engine.StartSupervised()
+
 	if err == nil {
 		t.Error("Expected error to be returned but was nil")
+	}
+
+	_, ok := err.(*TerminalError)
+	if !ok {
+		t.Error("Expected error to be of type TerminalError")
 	}
 }
 

--- a/packaging/amazon-linux-ami/ecs.service
+++ b/packaging/amazon-linux-ami/ecs.service
@@ -22,6 +22,7 @@ After=cloud-final.service
 [Service]
 Type=simple
 Restart=on-failure
+RestartPreventExitStatus=5
 RestartSec=10s
 EnvironmentFile=-/etc/ecs/ecs.config
 ExecStartPre=/usr/libexec/amazon-ecs-init pre-start


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Init is currently configured to restart on any failure. Today what happens is --

- Agent exits with code 5
- ecs-init, who monitors agent process status, received this error and kills itself with exit code -1.
- ecs-init restarts due to the restart policy 
- ecs-init restarts agent

Agent should not restart when it exits with exit code 5 as it is a terminal error code. This PR fixes this behavior. 

The behavior will be changed to --  
- Agent exits with code 5
- ecs-init, who monitors agent process status, received this error and kill itself with exit code 5.
- ecs-init does not restart as the restart policy is modified to not restart itself on exit code 5





### Testing
Agent exiting with exit code 5 can be replicated by adding an arbitrary capability to ecs.config - 
```
ECS_INSTANCE_ATTRIBUTES={"custom attribute !@#$%^&*": "custom_attribute_value"}
```

Montoring ecs-init after adding this capability, I can see Agent restarting again and again -- 

```
2021-01-21T19:50:36Z [INFO] Removing existing agent container ID: 2724ace14f79ebbb5f32c4b5614f85b36885377ee975b3378f287796c2b639d8
2021-01-21T19:50:36Z [INFO] Starting Amazon Elastic Container Service Agent
2021-01-21T19:50:38Z [INFO] Agent exited with code 5
2021-01-21T19:50:38Z [ERROR] agent exited with terminal exit code
2021-01-21T19:50:38Z [INFO] stop
2021-01-21T19:50:38Z [INFO] Stopping Amazon Elastic Container Service Agent
2021-01-21T19:50:38Z [INFO] Container name: /ecs-agent
2021-01-21T19:50:38Z [INFO] Agent is already stopped
2021-01-21T19:50:38Z [INFO] post-stop
2021-01-21T19:50:38Z [INFO] Cleaning up the credentials endpoint setup for Amazon Elastic Container Service Agent
2021-01-21T19:50:48Z [INFO] pre-start
2021-01-21T19:50:48Z [INFO] start
2021-01-21T19:50:48Z [INFO] Container name: /ecs-agent
2021-01-21T19:50:48Z [INFO] Removing existing agent container ID: 8582cbf6ebe0af6ff066139a22dea311a9c1c6995b6a5921a5bb593482ed2fe0
2021-01-21T19:50:48Z [INFO] Starting Amazon Elastic Container Service Agent



2021-01-21T19:50:49Z [INFO] Agent exited with code 5
2021-01-21T19:50:49Z [ERROR] agent exited with terminal exit code
2021-01-21T19:50:49Z [INFO] stop
2021-01-21T19:50:49Z [INFO] Stopping Amazon Elastic Container Service Agent
2021-01-21T19:50:49Z [INFO] Container name: /ecs-agent
2021-01-21T19:50:49Z [INFO] Agent is already stopped
2021-01-21T19:50:50Z [INFO] post-stop
2021-01-21T19:50:50Z [INFO] Cleaning up the credentials endpoint setup for Amazon Elastic Container Service Agent


2021-01-21T19:51:00Z [INFO] pre-start
2021-01-21T19:51:00Z [INFO] start
2021-01-21T19:51:00Z [INFO] Container name: /ecs-agent
2021-01-21T19:51:00Z [INFO] Removing existing agent container ID: 31a800c8fa6f810d5ecb7da9f801501ee6e0535b02bfe8eca39d6d0149fc8077
2021-01-21T19:51:00Z [INFO] Starting Amazon Elastic Container Service Agent
2021-01-21T19:51:01Z [INFO] Agent exited with code 5
2021-01-21T19:51:01Z [ERROR] agent exited with terminal exit code
2021-01-21T19:51:01Z [INFO] stop
```
With this change Agent is not restarted once it exits -- 
```
[ec2-user@ip-172-31-11-239 amazon-ecs-init]$ tail -f /var/log/ecs/ecs-init.log
2021-01-21T19:52:51Z [INFO] Removing existing agent container ID: e5310f89b1803dd3e1a3fb19623e872f11b5a2421bd5f1a0af712b79e0cd0ed3
2021-01-21T19:52:51Z [INFO] starting Amazon Elastic Container Service Agent
2021-01-21T19:52:52Z [INFO] Agent exited with code 5
2021-01-21T19:52:52Z [ERROR] terminal error with exit code: 5: agent exited with terminal exit code
2021-01-21T19:52:52Z [INFO] stop
2021-01-21T19:52:52Z [INFO] Stopping Amazon Elastic Container Service Agent
2021-01-21T19:52:52Z [INFO] Container name: /ecs-agent
2021-01-21T19:52:52Z [INFO] Agent is already stopped
2021-01-21T19:52:52Z [INFO] post-stop
2021-01-21T19:52:52Z [INFO] Cleaning up the credentials endpoint setup for Amazon Elastic Container Service Agent


```


New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
