### PR TITLE
Add generic rpm packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,18 @@ BUILDROOT/ecs-agent.tar:
 	mkdir -p BUILDROOT
 	curl -o BUILDROOT/ecs-agent.tar ${AGENT_URL}
 
+.generic-rpm-done:
+	./scripts/update-version.sh
+	cp packaging/generic-rpm/amazon-ecs-init.spec amazon-ecs-init.spec
+	cp packaging/generic-rpm/ecs.service ecs.service
+	tar -czf ./sources.tgz ecs-init scripts
+	test -e SOURCES || ln -s . SOURCES
+	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecs-init.spec
+	find RPMS/ -type f -exec cp {} . \;
+	touch .rpm-done
+
+generic-rpm: .generic-rpm-done
+
 .PHONY: deb
 deb: .deb-done
 .deb-done: BUILDROOT/ecs-agent.tar
@@ -156,7 +168,7 @@ clean:
 	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
 	-rm -rf ./x86_64
 	-rm -f ./amazon-ecs-init_${VERSION}*
-	-rm -f .srpm-done .rpm-done
+	-rm -f .srpm-done .rpm-done .generic-rpm-done
 	-rm -f .deb-done
 	-rm -f cover.out
 	-rm -f coverprofile.out

--- a/ecs-init/config/config_generic_rpm.go
+++ b/ecs-init/config/config_generic_rpm.go
@@ -1,0 +1,24 @@
+// +build generic-rpm
+
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+// This file contains the config used for generic rpm build.
+
+const (
+	cgroupMountpoint = "/sys/fs/cgroup"
+	hostCertsDirPath = ""
+	hostPKIDirPath   = ""
+)

--- a/packaging/generic-rpm/amazon-ecs-init.spec
+++ b/packaging/generic-rpm/amazon-ecs-init.spec
@@ -1,0 +1,96 @@
+# Copyright 2014-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+%global gobuild_tag generic-rpm
+%global _cachedir %{_localstatedir}/cache
+%global bundled_agent_version %{version}
+%global no_exec_perm 644
+
+%ifarch x86_64
+%global agent_image %{SOURCE3}
+%endif
+%ifarch aarch64
+%global agent_image %{SOURCE4}
+%endif
+
+Name:           amazon-ecs-init
+Version:        1.48.1
+Release:        1
+License:        Apache 2.0
+Summary:        Amazon Elastic Container Service initialization application
+ExclusiveArch:  x86_64 aarch64
+
+Source0:        sources.tgz
+Source1:        ecs.conf
+Source2:        ecs.service
+# x86_64 Container agent docker image
+Source3:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-v%{bundled_agent_version}.tar
+# aarch64 Container agent docker image
+Source4:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-arm64-v%{bundled_agent_version}.tar
+
+BuildRequires:  golang >= 1.7
+BuildRequires:  systemd
+Requires:       systemd
+Requires:       iptables
+Requires:       procps
+
+%description
+ecs-init supports the initialization and supervision of the Amazon ECS
+container agent, including configuration of cgroups, iptables, and
+required routes among its preparation steps.
+
+%prep
+%setup -c
+
+%build
+./scripts/gobuild.sh %{gobuild_tag}
+
+%install
+install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
+install -m %{no_exec_perm} -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
+
+mkdir -p %{buildroot}%{_sysconfdir}/ecs
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config
+touch %{buildroot}%{_sysconfdir}/ecs/ecs.config.json
+
+# Configure ecs-init to reload the bundled ECS container agent image.
+mkdir -p %{buildroot}%{_cachedir}/ecs
+echo 2 > %{buildroot}%{_cachedir}/ecs/state
+# Add a bundled ECS container agent image
+install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/
+
+mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
+
+install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+
+%files
+%{_libexecdir}/amazon-ecs-init
+%{_mandir}/man1/amazon-ecs-init.1*
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
+%config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
+%ghost %{_cachedir}/ecs/ecs-agent.tar
+%{_cachedir}/ecs/%{basename:%{agent_image}}
+%{_cachedir}/ecs/state
+%dir %{_sharedstatedir}/ecs/data
+%{_unitdir}/ecs.service
+
+%post
+# Symlink the bundled ECS Agent at loadable path.
+ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
+%systemd_post ecs
+
+%postun
+%systemd_postun
+
+%changelog

--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -1,0 +1,35 @@
+# Copyright 2014-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Amazon Elastic Container Service - container agent
+Documentation=https://aws.amazon.com/documentation/ecs/
+Requires=docker.service
+After=docker.service
+After=cloud-final.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10s
+EnvironmentFile=-/var/lib/ecs/ecs.config
+EnvironmentFile=-/etc/ecs/ecs.config
+ExecStartPre=/usr/libexec/amazon-ecs-init pre-start
+ExecStart=/usr/libexec/amazon-ecs-init start
+ExecStop=/usr/libexec/amazon-ecs-init stop
+ExecStopPost=/usr/libexec/amazon-ecs-init post-stop
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/suse/amazon-ecs-init.spec
+++ b/packaging/suse/amazon-ecs-init.spec
@@ -14,6 +14,7 @@
 
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
+# TODO: replace with generic rpm. Need to verify the latter works on EC2.
 
 %define short_name amazon-ecs
 Name:           amazon-ecs-init


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
### Summary
<!-- What does this pull request do? -->
Add generic rpm packaging (one that is not specific to platform). 

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
The changes include the following parts:
1. `packaging/generic-rpm/ecs-init.spec`: the rpm spec file used to built the rpm. This is written based on what we have on AL https://github.com/fenxiong/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs-init.spec, with the following notable differences:
* Remove all the AL1/upstart related logic and only use the AL2 part;
* Omit the distro part in https://github.com/aws/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs-init.spec#L36;
* Omit the docker dependency https://github.com/aws/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs-init.spec#L60. This is mainly because we have less control over docker outside of AL. it can come from "docker-ce", "docker" or "docker-ee", or even not from rpm. so i omit this dependency in packaging;
* Omit the provides statement https://github.com/aws/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs-init.spec#L71-L160. they are already outdated and not maintained so probably not needed i think. we can add them later if we find use case for them;
* Omit the changelog section since the code will not be in main branch in a while. they can be added later when ready to merge to main branch.
* Omit the volume plugin for now. They can be added later if needed. currently I have not tested the plugin.
2. `packaging/generic-rpm/ecs.service`: the systemd service file. this is basically the same as the one for AL, except i added "/var/lib/ecs/ecs.config" as another optional environment file, which is where we put "ECS_EXTERNAL" env and allows ecs init to use it in https://github.com/aws/amazon-ecs-init/pull/383
3. `Makefile`: added a target generic-rpm to build the rpm.

### Testing
<!-- How was this tested? -->
 Built the rpm and tested it on:
* Centos 7
* Centos 8
* RHEL 7
* Fedora 32
* opensuse/Tumbleweed

Verified that the service runs fine on these platforms.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
