### PR TITLE
Fix incorrect build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ clean:
 	-rm -rf ./bin
 	-rm -f ./sources.tgz
 	-rm -f ./amazon-ecs-init
+	-rm -f ./amazon-ecs-init-*.rpm
 	-rm -f ./ecs-agent-*.tar
 	-rm -f ./ecs-init-*.src.rpm
 	-rm -rf ./ecs-init-*

--- a/ecs-init/config/config_generic_rpm.go
+++ b/ecs-init/config/config_generic_rpm.go
@@ -1,4 +1,4 @@
-// +build generic-rpm
+// +build generic_rpm
 
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/ecs-init/config/config_unspecified.go
+++ b/ecs-init/config/config_unspecified.go
@@ -1,4 +1,4 @@
-// +build !suse,!ubuntu,!al2,!debian
+// +build !suse,!ubuntu,!al2,!debian,!generic_rpm
 
 // Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //

--- a/packaging/generic-rpm/amazon-ecs-init.spec
+++ b/packaging/generic-rpm/amazon-ecs-init.spec
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-%global gobuild_tag generic-rpm
+%global gobuild_tag generic_rpm
 %global _cachedir %{_localstatedir}/cache
 %global bundled_agent_version %{version}
 %global no_exec_perm 644


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix incorrect build tag. Build tag `generic-rpm` isn't valid due to containing dash, and then the build defaults to unspecified config. Changing to underscore `generic_rpm` to fix the issue.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Fix the build tag.

### Testing
<!-- How was this tested? -->
Built the rpm and verified that the agent cgroup mount is now correct (previously not)
```
{
    "Type": "bind",
    "Source": "/sys/fs/cgroup",
    "Destination": "/sys/fs/cgroup",
    "Mode": "",
    "RW": true,
    "Propagation": "rprivate"
},
```
and agent is able to create cgroup without error:
```
...
level=info time=2021-02-19T19:45:11Z msg="Creating root ecs cgroup: /ecs" module=init_linux.go
level=info time=2021-02-19T19:45:11Z msg="Creating cgroup /ecs" module=cgroup_controller_linux.go
level=info time=2021-02-19T19:45:11Z msg="Event stream ContainerChange start listening..." module=eventstream.go
...
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
