### PR TITLE
packaging/generic-deb: use agent version from file instead of tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-VERSION := $(shell git describe --tags | sed -e 's/v//' -e 's/-.*//')
+VERSION = $(shell cat ecs-init/ECSVERSION)
 
 .PHONY: dev generate lint static test build-mock-images sources rpm srpm govet
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
When we build a new version of ecs init package, the new agent version is available from file ecs-init/ECSVERSION, but not available from tag because the tag is created when we publish the release, but we build the package before that. This causes deb package build to use an agent version older than the release version.

Therefore, use the agent version from the ECSVERSION file instead of from `git describe --tags`.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Get agent version from `cat ecs-init/ECSVERSION` instead of from `git describe --tags`.

### Testing
<!-- How was this tested? -->
Built the deb package successfully. Verified that the version is read from file:
```
root@ip-172-31-12-102:/var/lib/ec2-stage/go/src/github.com/aws/amazon-ecs-init# make deb
./scripts/update-version.sh
++ dirname ./scripts/update-version.sh
+ CURRENTDIR=./scripts
++ cat ./scripts/../ecs-init/ECSVERSION
+ version=1.50.0
...
```


### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
