### PR TITLE
[wip] Add an ecs-ready service to generic deb and rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ BUILDROOT/ecs-agent.tar:
 	./scripts/update-version.sh
 	cp packaging/generic-rpm/amazon-ecs-init.spec amazon-ecs-init.spec
 	cp packaging/generic-rpm/ecs.service ecs.service
+	cp packaging/generic-rpm/ecs-ready.service ecs-ready.service
 	tar -czf ./sources.tgz ecs-init scripts
 	test -e SOURCES || ln -s . SOURCES
 	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecs-init.spec
@@ -156,6 +157,7 @@ clean:
 	-rm -f ecs-init.spec
 	-rm -f ecs.conf
 	-rm -f ecs.service
+	-rm -f ecs-ready.service
 	-rm -f amazon-ecs-volume-plugin.conf
 	-rm -f amazon-ecs-volume-plugin.service
 	-rm -f amazon-ecs-volume-plugin.socket

--- a/packaging/generic-deb/debian/ecs-ready.service
+++ b/packaging/generic-deb/debian/ecs-ready.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Amazon ECS Dependencies Loaded
+Documentation=https://aws.amazon.com/documentation/ecs/
+After=cloud-final.service
+RefuseManualStart=yes
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-deb/debian/ecs.service
+++ b/packaging/generic-deb/debian/ecs.service
@@ -17,10 +17,12 @@ Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
 Requires=docker.service
 After=docker.service
+Requires=ecs-ready.service
 
 [Service]
 Type=simple
 Restart=on-failure
+RestartPreventExitStatus=5
 RestartSec=10s
 EnvironmentFile=-/var/lib/ecs/ecs.config
 EnvironmentFile=-/etc/ecs/ecs.config

--- a/packaging/generic-deb/debian/rules
+++ b/packaging/generic-deb/debian/rules
@@ -20,3 +20,4 @@ override_dh_auto_install:
 	echo "2" >debian/amazon-ecs-init/var/cache/ecs/state
 	ln -s "/var/cache/ecs/ecs-agent-v${VERSION}.tar" debian/amazon-ecs-init/var/cache/ecs/ecs-agent.tar
 	dh_installsystemd --no-start --no-enable --name=ecs
+	dh_installsystemd --no-start --no-enable --name=ecs-ready

--- a/packaging/generic-rpm/amazon-ecs-init.spec
+++ b/packaging/generic-rpm/amazon-ecs-init.spec
@@ -38,6 +38,7 @@ Source2:        ecs.service
 Source3:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-v%{bundled_agent_version}.tar
 # aarch64 Container agent docker image
 Source4:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-arm64-v%{bundled_agent_version}.tar
+Source5:        ecs-ready.service
 
 BuildRequires:  golang >= 1.7
 BuildRequires:  systemd
@@ -73,6 +74,7 @@ install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/
 mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 
 install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+install -m %{no_exec_perm} -D %{SOURCE5} $RPM_BUILD_ROOT/%{_unitdir}/ecs-ready.service
 
 %files
 %{_libexecdir}/amazon-ecs-init
@@ -84,6 +86,7 @@ install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
 %{_unitdir}/ecs.service
+%{_unitdir}/ecs-ready.service
 
 %post
 # Symlink the bundled ECS Agent at loadable path.

--- a/packaging/generic-rpm/ecs-ready.service
+++ b/packaging/generic-rpm/ecs-ready.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Amazon ECS Dependencies Loaded
+Documentation=https://aws.amazon.com/documentation/ecs/
+After=cloud-final.service
+RefuseManualStart=yes
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -17,7 +17,7 @@ Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
 Requires=docker.service
 After=docker.service
-After=cloud-final.service
+Requires=ecs-ready.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
this enables the ecs service to be started within the cloud-final
service (userdata). The main purpose of this change is to enable users
to run the ecs anywhere install script in userdata.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
