### PR TITLE
A few fixes for ecs anywhere install

### DIFF
--- a/packaging/generic-rpm/ecs.service
+++ b/packaging/generic-rpm/ecs.service
@@ -17,7 +17,6 @@ Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
 Requires=docker.service
 After=docker.service
-After=cloud-final.service
 
 [Service]
 Type=simple

--- a/scripts/ecs-anywhere-install-instruction.md
+++ b/scripts/ecs-anywhere-install-instruction.md
@@ -33,4 +33,6 @@ Usage of ./ecs-anywhere-install.sh
     	(optional) ecs endpoint that can be used to different requests to ECS internal endpoints
   --skip-registration
     	(optional) if this is enabled, ssm agent install and instance registration with ssm is skipped
+  --no-start
+    	(optional) if this flag is provided, ssm agent, docker and ecs agent will not be started by the script despite being installed.
 ```


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
* Removed ecs init rpm dependency on cloud-init.final: this is to allow the script to be ran in userdata (or by cloud-init in general);
* Fixed ssm agent install error on suse due to gpg signature: added `--no-gpg-checks` option when install. the ssm agent gpg signature is a detached signature and we verify explicitly before install.
* Added an optional flag --no-start: this is mainly for testing purpose so we can replace the agent being used for testing.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Described above.

### Testing
<!-- How was this tested? -->
Tested on ubuntu20, centos8 and opensuse15. Tested `--no-start` option working and ssm/docker/ecs agent can be started fine after the script with `sudo systemctl start amazon-ssm-agent` and `sudo systemctl start ecs`. Also checked that without `--no-start` the script still works fine.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
