### PR TITLE
install script: check if dirmngr is installed before checking signature

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -528,6 +528,10 @@ ecs-init-signature-verify() {
         echo "WARNING: gpg command not available on this server, not able to verify amazon-ecs-init package signature."
         ok
         return
+    elif ! command -v dirmngr; then
+        echo "WARNING: dirmngr not installed on this server, not able to verify amazon-ecs-init package signature."
+        ok
+        return
     fi
 
     gpg --keyserver hkp://keys.gnupg.net:80 --recv BCE9D9A42D51784F


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Small fix in install script: check if dirmngr is installed before checking ecs init package signature. To import key with `gpg --key-server`, [dirmngr](https://www.gnupg.org/documentation/manuals/dirmngr/) needs to be installed. It is installed on most platforms by default but [might not be installed on debian](https://unix.stackexchange.com/questions/401547/gpg-keyserver-receive-failed-no-dirmngr)

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Fix by checking dirmngr installed or not before verifying signature.

### Testing
<!-- How was this tested? -->
Tessted on all ecs anywhere platforms. Fixed error on debian.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
N/A

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
