### PR TITLE
ecs-anywhere-install: allow sandboxed apt installations

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -317,6 +317,7 @@ install-ssm-agent() {
             curl-helper "$dir/$SSM_DEB_PKG_NAME" "$SSM_DEB_URL"
             curl-helper "$dir/$SSM_DEB_PKG_NAME.sig" "$SSM_DEB_URL.sig"
             ssm-agent-signature-verify "$dir/$SSM_DEB_PKG_NAME.sig" "$dir/$SSM_DEB_PKG_NAME"
+            chmod -R a+rX "$dir"
             dpkg -i "$dir/ssm-agent.deb"
             ;;
         dnf | yum | zypper)
@@ -477,6 +478,7 @@ install-ecs-agent() {
             curl-helper "$dir/$DEB_PKG_NAME.asc" "$DEB_URL.asc"
             ecs-init-signature-verify "$dir/$DEB_PKG_NAME.asc" "$dir/$DEB_PKG_NAME"
         fi
+        chmod -R a+rX "$dir"
         apt install -y "$dir/$DEB_PKG_NAME"
         rm -rf "$dir"
         ;;


### PR DESCRIPTION
Ensure the temporary directories into which package artifacts are downloaded are world-readable, thereby allowing the unprivileged `_apt` user to open the packages and allow for a sandboxed install.

This fix eliminates warnings such as:

```
N: Download is performed unsandboxed as root as file '/tmp/tmp.ZkW0dDLEph/amazon-ecs-init-latest.amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
```

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
