### PR TITLE
Fix download url for cn region

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -202,10 +202,10 @@ if grep -q "^cn-" <<< "$REGION"; then
 fi
 
 if [ -z "$RPM_URL" ]; then
-    RPM_URL="https://$S3_BUCKET.s3.amazonaws.com${S3_URL_SUFFIX}/$RPM_PKG_NAME"
+    RPM_URL="https://s3.${REGION}.amazonaws.com${S3_URL_SUFFIX}/${S3_BUCKET}/$RPM_PKG_NAME"
 fi
 if [ -z "$DEB_URL" ]; then
-    DEB_URL="https://$S3_BUCKET.s3.amazonaws.com${S3_URL_SUFFIX}/$DEB_PKG_NAME"
+    DEB_URL="https://s3.${REGION}.amazonaws.com${S3_URL_SUFFIX}/${S3_BUCKET}/$DEB_PKG_NAME"
 fi
 
 # source /etc/os-release to get the VERSION_ID and ID fields
@@ -352,7 +352,7 @@ ssm-agent-signature-verify() {
         return
     fi
 
-    curl-helper "$dir/amazon-ssm-agent.gpg" "https://raw.githubusercontent.com/aws/amazon-ecs-init/dev/scripts/amazon-ssm-agent.gpg"
+    curl-helper "$dir/amazon-ssm-agent.gpg" "https://raw.githubusercontent.com/aws/amazon-ecs-init/master/scripts/amazon-ssm-agent.gpg"
     local fp
     fp=$(gpg --quiet --with-colons --with-fingerprint "$dir/amazon-ssm-agent.gpg" | awk -F: '$1 == "fpr" {print $10;}')
     echo "$fp"
@@ -540,8 +540,7 @@ ecs-init-signature-verify() {
         return
     fi
 
-    # TODO: change link to official repo after merging first time.
-    curl-helper "$dir/amazon-ecs-agent.gpg" "https://raw.githubusercontent.com/fenxiong/amazon-ecs-init/ecs-pubkey/scripts/amazon-ecs-agent.gpg"
+    curl-helper "$dir/amazon-ecs-agent.gpg" "https://raw.githubusercontent.com/aws/amazon-ecs-init/master/scripts/amazon-ecs-agent.gpg"
     gpg --import "$dir/amazon-ecs-agent.gpg"
     if gpg --verify "$1" "$2"; then
         echo "amazon-ecs-init GPG verification passed. Install amazon-ecs-init."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix rpm/deb download url for cn region, previously incorrect; also update link of the ssm/ecs agent public key to more official location.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Fix the url; update links.

### Testing
<!-- How was this tested? -->
Tested manually on ubuntu and centos for cn region. Also ran through the e2e tests for cn and some other regions.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
ecs-anywhere-install: fix incorrect download url when running in cn region.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
