### PR TITLE
Update the packaging data for SUSE

### DIFF
--- a/packaging/suse/amazon-ecs-init.changes
+++ b/packaging/suse/amazon-ecs-init.changes
@@ -1,497 +1,202 @@
 -------------------------------------------------------------------
-Tue May 25, 19:30:00 UTC 2021 - fenxiong@amazon.com - 1.52.2-2
+Wed May 26 11:33:16 UTC 2021 - Robert Schweikert <rjschwei@suse.com>
 
-- Cache Agent version 1.52.2
-- ecs-anywhere-install: fix incorrect download url when running in cn region
--------------------------------------------------------------------
-Thu May 20, 01:00:00 UTC 2021 - fenxiong@amazon.com - 1.52.2-1
-
-- Cache Agent version 1.52.2
-- ecs-anywhere-install: remove dependency on gpg key server
-- ecs-anywhere-install: allow sandboxed apt installations
--------------------------------------------------------------------
-Fri May 14, 18:40:00 UTC 2021 - fenxiong@amazon.com - 1.52.1-1
-
-- Cache Agent version 1.52.1
--------------------------------------------------------------------
-Wed Apr 28, 20:05:00 UTC 2021 - fierlion@amazon.com - 1.52.0-1
-
-- Cache Agent version 1.52.0
-- Add support for ECS EXTERNAL launch type (ECS Anywhere)
--------------------------------------------------------------------
-Wed Mar 31, 09:32:00 UTC 2021 - shugy@amazon.com - 1.51.0-1
-
-- Cache Agent version 1.51.0
--------------------------------------------------------------------
-Wed Mar 17, 18:02:00 UTC 2021 - mythr@amazon.com - 1.50.3-1
-
-- Cache Agent version 1.50.3
--------------------------------------------------------------------
-Fri Feb 19, 19:03:32 UTC 2021 - mssrivas@amazon.com - 1.50.2-1
-
-- Cache Agent version 1.50.2
--------------------------------------------------------------------
-Wed Feb 10, 20:43:00 UTC 2021 - shugy@amazon.com - 1.50.1-1
-
-- Cache Agent version 1.50.1
-- Does not restart ECS Agent when it exits with exit code 5
--------------------------------------------------------------------
-Fri Jan 22, 11:54:00 UTC 2021 - utsa@amazon.com - 1.50.0-1
-
-- Cache Agent version 1.50.0
-- Allows ECS customers to execute interactive commands inside containers.
--------------------------------------------------------------------
-Wed Jan 06, 11:54:00 UTC 2021 - shugy@amazon.com - 1.49.0-1
-
-- Cache Agent version 1.49.0
-- Removes iptable rule that drops packets to port 51678 unconditionally on ecs service stop
--------------------------------------------------------------------
-Mon Nov 23, 11:54:00 UTC 2020 - shugy@amazon.com - 1.48.1-1
-
-- Cache Agent version 1.48.1
--------------------------------------------------------------------
-Thu Nov 19, 20:19:00 UTC 2020 - shugy@amazon.com - 1.48.0-2
-
-- Cache Agent version 1.48.0
--------------------------------------------------------------------
-Fri Oct 30, 19:00:00 UTC 2020 - mythr@amazon.com - 1.47.0-1
-
-- Cache Agent version 1.47.0
--------------------------------------------------------------------
-Fri Oct 16, 19:03:32 UTC 2020 - mssrivas@amazon.com - 1.46.0-1
-
-- Cache Agent version 1.46.0
--------------------------------------------------------------------
-Wed Sep 30, 19:00:00 UTC 2020 - cssparr@amazon.com - 1.45.0-1
-
-- Cache Agent version 1.45.0
-- Block offhost access to agent's introspection port by default. Configurable via env ECS_ALLOW_OFFHOST_INTROSPECTION_ACCESS
--------------------------------------------------------------------
-Tue Sep 15, 19:34:32 UTC 2020 - fierlion@amazon.com - 1.44.4-1
-
-- Cache Agent version 1.44.4
--------------------------------------------------------------------
-Wed Sep 02, 19:03:32 UTC 2020 - mssrivas@amazon.com - 1.44.3-1
-
-- Cache Agent version 1.44.3
--------------------------------------------------------------------
-Wed Aug 26, 19:03:32 UTC 2020 - utsa@amazon.com - 1.44.2-1
-
-- Cache Agent version 1.44.2
--------------------------------------------------------------------
-Thu Aug 20, 18:35:32 UTC 2020 - shugy@amazon.com - 1.44.1-1
-
-- Cache Agent version 1.44.1
--------------------------------------------------------------------
-Thu Aug 13, 20:39:32 UTC 2020 - shugy@amazon.com - 1.44.0-1
-
-- Cache Agent version 1.44.0
-- Add support for configuring Agent container logs
--------------------------------------------------------------------
-Tue Aug 04, 17:22:32 UTC 2020 - fenxiong@amazon.com - 1.43.0-2
-
-- Cache Agent version 1.43.0
--------------------------------------------------------------------
-Thu Jul 23, 17:55:00 UTC 2020 - yhlee@amazon.com - 1.42.0-1
-
-- Cache Agent version 1.42.0
-- Add a flag ECS_SKIP_LOCALHOST_TRAFFIC_FILTER to allow skipping local traffic filtering
--------------------------------------------------------------------
-Thu Jul 09, 00:46:00 UTC 2020 - fenxiong@amazon.com - 1.41.1-2
-
-- Drop traffic to 127.0.0.1 that isn't originated from the host
--------------------------------------------------------------------
-Mon Jul 06, 23:45:00 UTC 2020 - cya@amazon.com - 1.41.1-1
-
-- Cache Agent version 1.41.1
--------------------------------------------------------------------
-Mon Jun 22, 23:45:00 UTC 2020 - mssrivas@amazon.com - 1.41.0-1
-
-- Cache Agent version 1.41.0
--------------------------------------------------------------------
-Tue Jun 02, 23:45:00 UTC 2020 - mssrivas@amazon.com - 1.40.0-1
-
-- Cache Agent version 1.40.0
--------------------------------------------------------------------
-Fri Apr 03, 19:04:00 UTC 2020 - yhlee@amazon.com - 1.39.0-2
-
-- Cache Agent version 1.39.0
-- Ignore IPv6 disable failure if already disabled
--------------------------------------------------------------------
-Thu Mar 19, 21:42:00 UTC 2020 - sharanyd@amazon.com - 1.38.0-1
-
-- Cache Agent version 1.38.0
-- Adds support for ECS volume plugin
-- Disable ipv6 router advertisements for optimization
--------------------------------------------------------------------
-Sat Feb 22, 01:40:00 UTC 2020 - youngli@amazon.com - 1.37.0-2
-
-- Cache Agent version 1.37.0
-- Add '/etc/alternatives' to mounts
--------------------------------------------------------------------
-Tue Feb 04, 22:32:00 UTC 2020 - fierlion@amazon.com - 1.36.2-1
-
-- Cache Agent version 1.36.2
-- update sbin mount point to avoid conflict with Docker >= 19.03.5
--------------------------------------------------------------------
-Fri Jan 10, 19:00:00 UTC 2020 - yhlee@amazon.com - 1.36.1-1
-
-- Cache Agent version 1.36.1
--------------------------------------------------------------------
-Wed Jan 08, 19:00:00 UTC 2020 - cssparr@amazon.com - 1.36.0-1
-
-- Cache Agent version 1.36.0
-- capture a fixed tail of container logs when removing a container
--------------------------------------------------------------------
-Thu Dec 12, 17:00:00 UTC 2019 - petderek@amazon.com - 1.35.0-1
-
-- Cache Agent version 1.35.0
-- Fix bug where stopping agent gracefully would still restart ecs-init
--------------------------------------------------------------------
-Mon Nov 11, 17:00:00 UTC 2019 - shugy@amazon.com - 1.33.0-1
-
-- Cache Agent version 1.33.0
-- Fix destination path in docker socket bind mount to match the one specified using DOCKER_HOST on Amazon Linux 2
--------------------------------------------------------------------
-Mon Oct 28, 17:00:00 UTC 2019 - shugy@amazon.com - 1.32.1-1
-
-- Cache Agent version 1.32.1
-- Add the ability to set Agent container's labels
--------------------------------------------------------------------
-Wed Sep 25, 18:00:00 UTC 2019 - cssparr@amazon.com - 1.32.0-1
-
-- Cache Agent version 1.32.0
--------------------------------------------------------------------
-Fri Sep 13, 18:00:00 UTC 2019 - cya@amazon.com - 1.31.0-1
+- Add use-agent-container-built-in-certs.patch to use the built in certs from
+  the downloaded agent container
+- Update amazon-ecs.service to consider the proper environment files
+- Set the cache state to ensure the latest agent container gets pulled
 
-- Cache Agent version 1.31.0
 -------------------------------------------------------------------
-Thu Aug 15, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.30.0-1
+Wed May 19 18:19:51 UTC 2021 - Robert Schweikert <rjschwei@suse.com>
 
-- Cache Agent version 1.30.0
--------------------------------------------------------------------
-Mon Jul 08, 19:06:00 UTC 2019 - shugy@amazon.com - 1.29.1-1
-
-- Cache Agent version 1.29.1
--------------------------------------------------------------------
-Thu Jun 06, 22:47:00 UTC 2019 - yumex@amazon.com - 1.29.0-1
-
-- Cache Agent version 1.29.0
--------------------------------------------------------------------
-Fri May 31, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.28.1-2
-
-- Cache Agent version 1.28.1
-- Use exponential backoff when restarting agent
--------------------------------------------------------------------
-Thu May 09, 18:00:00 UTC 2019 - fenxiong@amazon.com - 1.28.0-1
-
-- Cache Agent version 1.28.0
--------------------------------------------------------------------
-Thu Mar 28, 22:00:00 UTC 2019 - obo@amazon.com - 1.27.0-1
-
-- Cache Agent version 1.27.0
--------------------------------------------------------------------
-Thu Mar 21, 21:30:00 UTC 2019 - petderek@amazon.com - 1.26.1-1
-
-- Cache Agent version 1.26.1
--------------------------------------------------------------------
-Thu Feb 28, 21:30:00 UTC 2019 - petderek@amazon.com - 1.26.0-1
-
-- Cache Agent version 1.26.0
-- Add support for running iptables within agent container
--------------------------------------------------------------------
-Fri Feb 15, 19:30:00 UTC 2019 - fierlion@amazon.com - 1.25.3-1
-
-- Cache Agent version 1.25.3
--------------------------------------------------------------------
-Thu Jan 31, 19:53:00 UTC 2019 - obo@amazon.com - 1.25.2-1
-
-- Cache Agent version 1.25.2
--------------------------------------------------------------------
-Sat Jan 26, 04:39:00 UTC 2019 - adnkha@amazon.com - 1.25.1-1
-
-- Cache Agent version 1.25.1
-- Update ecr models for private link support
--------------------------------------------------------------------
-Thu Jan 17, 18:32:18 UTC 2019 - yuzhusun@amazon.com - 1.25.0-1
-
-- Cache Agent version 1.25.0
-- Add Nvidia GPU support for p2 and p3 instances
--------------------------------------------------------------------
-Fri Jan 04, 18:16:18 UTC 2019 - yuzhusun@amazon.com - 1.24.0-1
-
-- Cache Agent version 1.24.0
--------------------------------------------------------------------
-Fri Nov 16, 19:00:00 UTC 2018 - jakeev@amazon.com - 1.22.0-4
-
-- Cache ECS agent version 1.22.0 for x86_64 & ARM
-- Support ARM architecture builds
--------------------------------------------------------------------
-Thu Nov 15, 19:00:00 UTC 2018 - jakeev@amazon.com - 1.22.0-3
-
-- Rebuild
--------------------------------------------------------------------
-Fri Nov 02, 17:51:28 UTC 2018 - yhlee@amazon.com - 1.22.0-2
-
-- Cache Agent version 1.22.0
--------------------------------------------------------------------
-Thu Oct 11, 18:49:28 UTC 2018 - sharanyd@amazon.com - 1.21.0-1
-
-- Cache Agent version 1.21.0
-- Support configurable logconfig for Agent container to reduce disk usage
-- ECS Agent will use the host's cert store on the Amazon Linux platform
--------------------------------------------------------------------
-Fri Sep 14, 00:38:10 UTC 2018 - yumex@amazon.com - 1.20.3-1
-
-- Cache Agent version 1.20.3
--------------------------------------------------------------------
-Fri Aug 31, 00:43:01 UTC 2018 - fenxiong@amazon.com - 1.20.2-1
+- Update to version 1.52.1 (bsc#1186239, bsc#1186262)
+  + Cache Agent version 1.52.1
+  + Add support for ECS EXTERNAL launch type (ECS Anywhere)
 
-- Cache Agent version 1.20.2
 -------------------------------------------------------------------
-Thu Aug 09, 00:04:01 UTC 2018 - penyin@amazon.com - 1.20.1-1
+Mon Mar 15 13:51:52 UTC 2021 - Robert Schweikert <rjschwei@suse.com>
 
-- Cache Agent version 1.20.1
--------------------------------------------------------------------
-Wed Aug 01, 23:44:01 UTC 2018 - haikuo@amazon.com - 1.20.0-1
-
-- Cache Agent version 1.20.0
--------------------------------------------------------------------
-Thu Jul 26, 21:31:24 UTC 2018 - haikuo@amazon.com - 1.19.1-1
-
-- Cache Agent version 1.19.1
--------------------------------------------------------------------
-Thu Jul 19, 23:09:41 UTC 2018 - fenxiong@amazon.com - 1.19.0-1
-
-- Cache Agent version 1.19.0
--------------------------------------------------------------------
-Wed May 23, 19:00:00 UTC 2018 - iweller@amazon.com - 1.18.0-2
-
-- Spec file cleanups
-- Enable builds for both AL1 and AL2
--------------------------------------------------------------------
-Fri May 04, 21:30:22 UTC 2018 - haikuo@amazon.com - 1.18.0-1
+- Add info about bundled dependencies in spec
+- Fix required go version
+- Handle go 1.16 or later by switching GO111MODULE to previous default
 
-- Cache Agent version 1.18.0
-- Add support for regional buckets
-- Bundle ECS Agent tarball in package
-- Download agent based on the partition
-- Mount Docker plugin files dir
 -------------------------------------------------------------------
-Fri Mar 30, 20:20:41 UTC 2018 - jushay@amazon.com - 1.17.3-1
+Fri Feb 26 14:52:15 UTC 2021 - Robert Schweikert <rjschwei@suse.com>
 
-- Cache Agent version 1.17.3
-- Use s3client instead of httpclient when downloading
--------------------------------------------------------------------
-Mon Mar 05, 18:31:19 UTC 2018 - jakeev@amazon.com - 1.17.2-1
-
-- Cache Agent version 1.17.2
--------------------------------------------------------------------
-Mon Feb 19, 18:57:33 UTC 2018 - jushay@amazon.com - 1.17.1-1
-
-- Cache Agent version 1.17.1
--------------------------------------------------------------------
-Mon Feb 05, 18:03:33 UTC 2018 - jushay@amazon.com - 1.17.0-2
+- Only build for x86_64 and aarch64
 
-- Cache Agent version 1.17.0
 -------------------------------------------------------------------
-Tue Jan 16, 18:12:56 UTC 2018 - petderek@amazon.com - 1.16.2-1
+Tue Feb 16 21:33:19 UTC 2021 - Robert Schweikert <rjschwei@suse.com>
 
-- Cache Agent version 1.16.2
-- Add GovCloud endpoint
--------------------------------------------------------------------
-Wed Jan 03, 22:52:56 UTC 2018 - nmeyerha@amazon.com - 1.16.1-1
+- Update to version 1.50.1 (bsc#1182343, bsc#1182344)
+  + Cache Agent version 1.50.1
+  + Does not restart ECS Agent when it exits with exit code 5
+- For detailed changes between the previous version and this version see
+  the included Changelog.md file
 
-- Cache Agent version 1.16.1
-- Improve startup behavior when Docker socket doesn't exist yet
 -------------------------------------------------------------------
-Tue Nov 21, 21:03:59 UTC 2017 - nmeyerha@amazon.com - 1.16.0-1
+Mon Feb  3 11:59:20 UTC 2020 - Dominique Leuenberger <dimstar@opensuse.org>
 
-- Cache Agent version 1.16.0
--------------------------------------------------------------------
-Wed Nov 15, 00:53:54 UTC 2017 - nmeyerha@amazon.com - 1.15.2-1
+- BuildRequire pkgconfig(systemd) instead of systemd: allow OBS to
+  shortcut through the -mini flavors.
 
-- Cache Agent version 1.15.2
 -------------------------------------------------------------------
-Tue Oct 17, 15:55:19 UTC 2017 - jakeev@amazon.com - 1.15.1-1
+Wed Apr  3 18:45:07 UTC 2019 - Robert Schweikert <rjschwei@suse.com>
 
-- Update ECS Agent version
--------------------------------------------------------------------
-Sat Oct 07, 07:50:23 UTC 2017 - jushay@amazon.com - 1.15.0-1
+- Enable aarch64 build (bsc#1131459)
 
-- Update ECS Agent version
 -------------------------------------------------------------------
-Sat Sep 30, 01:36:34 UTC 2017 - jushay@amazon.com - 1.14.5-1
+Thu Aug 30 09:25:08 UTC 2018 - bwiedemann@suse.com
 
-- Update ECS Agent version
--------------------------------------------------------------------
-Tue Aug 22, 23:44:03 UTC 2017 - jushay@amazon.com - 1.14.4-1
+- Add reproducible.patch to use constant build path (boo#1062303)
 
-- Update ECS Agent version
 -------------------------------------------------------------------
-Thu Jun 01, 19:00:00 UTC 2017 - adnkha@amazon.com - 1.14.2-2
+Tue Jul 17 11:54:46 UTC 2018 - adrian.glaubitz@suse.com
 
-- Cache Agent version 1.14.2
-- Add functionality for running agent with userns=host when Docker has userns-remap enabled
-- Add support for Docker 17.03.1ce
--------------------------------------------------------------------
-Mon Mar 06, 19:00:00 UTC 2017 - adnkha@amazon.com - 1.14.1-1
+- Update to version 1.18.0
+  + Cache Agent version 1.18.0
+  + Add support for regional buckets
+  + Bundle ECS Agent tarball in package
+  + Download agent based on the partition
+  + Mount Docker plugin files dir
 
-- Cache Agent version 1.14.1
 -------------------------------------------------------------------
-Wed Jan 25, 19:00:00 UTC 2017 - aithal@amazon.com - 1.14.0-2
+Fri May 25 12:53:24 UTC 2018 - rjschwei@suse.com
 
-- Add retry-backoff for pinging the Docker socket when creating the Docker client
--------------------------------------------------------------------
-Mon Jan 16, 19:00:00 UTC 2017 - petderek@amazon.com - 1.14.0-1
+- Modify dependencies to work around module dependency issues in SLE
 
-- Cache Agent version 1.14.0
 -------------------------------------------------------------------
-Fri Jan 06, 19:00:00 UTC 2017 - nmeyerha@amazon.com - 1.13.1-2
+Tue May 22 13:42:50 UTC 2018 - rjschwei@suse.com
 
-- Update Requires to indicate support for docker <= 1.12.6
--------------------------------------------------------------------
-Mon Nov 14, 19:00:00 UTC 2016 - penyin@amazon.com - 1.13.1-1
+- Update to version 1.17.3
+  + No upstream changelog
 
-- Cache Agent version 1.13.1
 -------------------------------------------------------------------
-Tue Sep 27, 19:00:00 UTC 2016 - nmeyerha@amazon.com - 1.13.0-1
+Thu Nov  3 22:35:12 UTC 2016 - rjschwei@suse.com
 
-- Cache Agent version 1.13.0
--------------------------------------------------------------------
-Tue Sep 13, 19:00:00 UTC 2016 - aithal@amazon.com - 1.12.2-1
+- Service needs to run after we know the network is fully configured
+  thus use network-online.target instead of network.target
 
-- Cache Agent version 1.12.2
 -------------------------------------------------------------------
-Wed Aug 17, 19:00:00 UTC 2016 - penyin@amazon.com - 1.12.1-1
+Thu Nov  3 12:00:29 UTC 2016 - rjschwei@suse.com
 
-- Cache Agent version 1.12.1
--------------------------------------------------------------------
-Wed Aug 10, 19:00:00 UTC 2016 - aithal@amazon.com - 1.12.0-1
+- Update to version 1.13.0 (bsc#1008298)
+  + Cache agent version 1.13.0
+- From 1.12.2
+  + Cache Agent version 1.12.2
+- From 1.12.1
+  + Cache Agent version 1.12.1
+- From 1.12.0
+  + Enable Task IAM Role for containers launched with 'host' network mode
+  + Cache Agent version 1.12.0
+- From 1.11.1
+  + Cache Agent version 1.11.1
+- From 1.11.0
+  + Enhancement - Support Task IAM Roles feature of Agent
+  + Enhancement - Start Agent with host network mode
+  + Enhancement - Cache Agent version 1.11.0
+  + Enhancement - Add support for Docker 1.11.2
+- From 1.10.0
+  + Enhancement - Cache Agent version 1.10.0
+  + Enhancement - Add support for Docker 1.11.1
+- From 1.9.0
+  + Enhancement - Cache Agent version 1.9.0
+ - From 1.8.2
+  + Enhancement - Cache Agent version 1.8.2
+- From 1.8.1
+  + Enhancement - Cache Agent version 1.8.1
 
-- Cache Agent version 1.12.0
-- Add netfilter rules to support host network reaching credentials proxy
 -------------------------------------------------------------------
-Wed Aug 03, 19:00:00 UTC 2016 - skarp@amazon.com - 1.11.1-1
+Wed Jan 27 19:25:00 UTC 2016 - rjschwei@suse.com
 
-- Cache Agent version 1.11.1
--------------------------------------------------------------------
-Tue Jul 05, 19:00:00 UTC 2016 - skarp@amazon.com - 1.11.0-1
+- Update to version 1.7.1 (bsc#963837)
+  + remove cgroup_location.patch, system path is integrated in build
+    configuration
+  + Cache Agent version 1.7.1
+- From 1.7.0
+  + Cache Agent version 1.7.0
+  + Add support for Docker 1.9.1
+- From 1.6.0
+  + Cache Agent version 1.6.0
+  + Updated source dependencies
 
-- Cache Agent version 1.11.0
-- Add support for Docker 1.11.2
-- Modify iptables and netfilter to support credentials proxy
-- Eliminate requirement that /tmp and /var/cache be on the same filesystem
-- Start agent with host network mode
 -------------------------------------------------------------------
-Mon May 23, 19:00:00 UTC 2016 - penyin@amazon.com - 1.10.0-1
+Thu Oct  8 21:44:45 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.10.0
-- Add support for Docker 1.11.1
--------------------------------------------------------------------
-Tue Apr 26, 19:00:00 UTC 2016 - penyin@amazon.com - 1.9.0-1
+- Update to version 1.5.0 (bsc#949602)
+  + Enhancement - Cache Agent version 1.5.0
+  + Enhancement - Improved merge strategy for user-supplied environment
+  + Enhancement - Add default supported logging drivers
+- Add build switch for SUSE, modify cgroup_location.patch
 
-- Cache Agent version 1.9.0
-- Make awslogs driver available by default
 -------------------------------------------------------------------
-Thu Mar 24, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.2-1
+Mon Sep 28 13:04:58 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.8.2
--------------------------------------------------------------------
-Mon Feb 29, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.1-1
+- Update long description
 
-- Cache Agent version 1.8.1
 -------------------------------------------------------------------
-Wed Feb 10, 19:00:00 UTC 2016 - rhenalsj@amazon.com - 1.8.0-1
+Sun Sep 27 13:08:42 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.8.0
--------------------------------------------------------------------
-Fri Jan 08, 19:00:00 UTC 2016 - skarp@amazon.com - 1.7.1-1
+- Add patch cgroup_location.patch
+  + Modify location where the agent looks for cgroup information
 
-- Cache Agent version 1.7.1
 -------------------------------------------------------------------
-Tue Dec 08, 19:00:00 UTC 2015 - skarp@amazon.com - 1.7.0-1
+Thu Sep 24 20:16:36 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.7.0
-- Add support for Docker 1.9.1
--------------------------------------------------------------------
-Wed Oct 21, 19:00:00 UTC 2015 - skarp@amazon.com - 1.6.0-1
+- Drop the extra version number
+  + Going forward we do not care about picking up -x tarball releases
+    the do not contain source changes
 
-- Cache Agent version 1.6.0
-- Updated source dependencies
 -------------------------------------------------------------------
-Wed Sep 23, 19:00:00 UTC 2015 - skarp@amazon.com - 1.5.0-1
+Thu Sep 24 17:56:40 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.5.0
-- Improved merge strategy for user-supplied environment variables
-- Add default supported logging drivers
--------------------------------------------------------------------
-Wed Aug 26, 19:00:00 UTC 2015 - skarp@amazon.com - 1.4.0-2
+- Rename the service file, request from upstream
+- Spec file improvements to better match the requirements of the code
 
-- Add support for Docker 1.7.1
 -------------------------------------------------------------------
-Tue Aug 11, 19:00:00 UTC 2015 - skarp@amazon.com - 1.4.0-1
+Tue Sep 22 14:48:33 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.4.0
--------------------------------------------------------------------
-Thu Jul 30, 19:00:00 UTC 2015 - skarp@amazon.com - 1.3.1-1
+- Update to version 1.4.0.2 (1.4.0-2 upstream)
+  + Enhancement - Add support for Docker 1.7.1
+  + Enhancement: Cache Agent version 1.4.0
+  + Feature: Read Docker endpoint from environment variable
+    DOCKER_HOST if present
 
-- Cache Agent version 1.3.1
-- Read Docker endpoint from environment variable DOCKER_HOST if present
 -------------------------------------------------------------------
-Thu Jul 02, 19:00:00 UTC 2015 - skarp@amazon.com - 1.3.0-1
+Tue Sep 22 12:28:32 CEST 2015 - lchiquitto@suse.de
 
-- Cache Agent version 1.3.0
--------------------------------------------------------------------
-Fri Jun 19, 19:00:00 UTC 2015 - euank@amazon.com - 1.2.1-2
+- Set ExclusiveArch to disable building on architectures not
+  supported by Go.
 
-- Cache Agent version 1.2.1
 -------------------------------------------------------------------
-Tue Jun 02, 19:00:00 UTC 2015 - skarp@amazon.com - 1.2.0-1
+Mon Aug 10 17:18:13 UTC 2015 - rjschwei@suse.com
 
-- Update versioning scheme to match Agent version
-- Cache Agent version 1.2.0
-- Mount cgroup and execdriver directories for Telemetry feature
--------------------------------------------------------------------
-Mon Jun 01, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-5
+- Include in SLE 12 (fate#319338)
+  + Also related to fate#318337
 
-- Add support for Docker 1.6.2
 -------------------------------------------------------------------
-Mon May 11, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-4
+Mon Aug 10 17:10:53 UTC 2015 - rjschwei@suse.com
 
-- Properly restart if the ecs-init package is upgraded in isolation
--------------------------------------------------------------------
-Wed May 06, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-3
+- go is only a BuildRequires as go is completely static and we need
+  no runtime bits and pieces
 
-- Restart on upgrade if already running
 -------------------------------------------------------------------
-Tue May 05, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-2
+Wed Aug  5 18:45:57 UTC 2015 - rjschwei@suse.com
 
-- Cache Agent version 1.1.0
-- Add support for Docker 1.6.0
-- Force cache load on install/upgrade
-- Add man page
--------------------------------------------------------------------
-Thu Mar 26, 19:00:00 UTC 2015 - skarp@amazon.com - 1.0-1
+- Use the systemd unit file as source, no need to wrap it in a tarball
 
-- Re-start Agent on non-terminal exit codes
-- Enable Agent self-updates
-- Cache Agent version 1.0.0
-- Added rollback to cached Agent version for failed updates
 -------------------------------------------------------------------
-Mon Mar 16, 19:00:00 UTC 2015 - skarp@amazon.com - 0.3-0
+Wed Aug  5 09:21:51 UTC 2015 - ms@suse.com
 
-- Migrate to statically-compiled Go binary
--------------------------------------------------------------------
-Tue Feb 17, 19:00:00 UTC 2015 - ericn@amazon.com - 0.2-3
+- Update to version 1.3.1
+  + Added systemd unit script for start/stop
+  + Added activation/deactivation of service in spec file
 
-- Test for existing container agent and force remove it
 -------------------------------------------------------------------
-Thu Jan 15, 19:00:00 UTC 2015 - skarp@amazon.com - 0.2-2
+Mon Jun  1 17:41:41 UTC 2015 - rjschwei@suse.com
 
-- Mount data directory for state persistence
-- Enable JSON-based configuration
--------------------------------------------------------------------
-Mon Dec 15, 19:00:00 UTC 2014 - skarp@amazon.com - 0.2-1
+- Initial build
+  + Version 1.0-3
+  + Not ready for use, still experimenting but need to share to push the
+    work forward. The systemd init files need to be sorted out
 
-- Naive update functionality

--- a/packaging/suse/amazon-ecs-init.spec
+++ b/packaging/suse/amazon-ecs-init.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package amazon-ecs-init
 #
-# Copyright (c) 2015 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,37 +12,141 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
-# TODO: replace with generic rpm. Need to verify the latter works on EC2.
+
 
 %define short_name amazon-ecs
 Name:           amazon-ecs-init
-Version:        1.7.1
+Version:        1.52.1
 Release:        0
-Summary:        Amazon Elastic Container Service Initialization
+Summary:        Amazon EC2 Container Service Initialization
 License:        Apache-2.0
 Group:          System Environment/Base
-Url:            https://github.com/aws/amazon-ecs-init
-Source0:        %{name}-%{version}.tar.gz
+URL:            https://github.com/aws/amazon-ecs-init
+Source0:        %{name}-%{version}-1.tar.gz
 Source1:        %{short_name}.service
-BuildRequires:  go
-BuildRequires:  systemd
-Requires:       docker >= 1.6.0
+# Patch local to openSUSE Build service to get reproducible builds
+#Patch0:         reproducible.patch
+# Patch local to openSUSE Build service until we sort out the cert handling
+# for server validation.
+#Patch1:         use-agent-container-built-in-certs.patch
+BuildRequires:  go  >= 1.7
+BuildRequires:  pkgconfig(systemd)
+# We cannot handle cross module dependencies properly, i.e. one module can
+# only depend on one other module, instead of having a one to many
+# dependency construct. While docker is a hard requirement this cannot be
+# expressed here and we use Recommends. AS we want to have openSUSE and SLE
+# behave in the same way openSUSE has to suffer the same "brokenness"
+Recommends:     docker >= 1.6.0
 Requires:       systemd
+Provides:       bundled(golang(github.com/Azure/go-ansiterm))
+Provides:       bundled(golang(github.com/Azure/go-ansiterm/winterm))
+Provides:       bundled(golang(github.com/Microsoft/go-winio))
+Provides:       bundled(golang(github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml))
+Provides:       bundled(golang(github.com/Nvveen/Gotty))
+Provides:       bundled(golang(github.com/Sirupsen/logrus))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/awserr))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/awsutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/client))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/client/metadata))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/corehandlers))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/endpointcreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/stscreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/defaults))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/ec2metadata))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/endpoints))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/request))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/session))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/signer/v4))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/sdkio))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/sdkrand))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/shareddefaults))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/query))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/query/queryutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/rest))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/restxml))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/s3))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/s3/s3iface))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/s3/s3manager))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/sts))
+Provides:       bundled(golang(github.com/cihub/seelog))
+Provides:       bundled(golang(github.com/cihub/seelog/archive))
+Provides:       bundled(golang(github.com/cihub/seelog/archive/gzip))
+Provides:       bundled(golang(github.com/cihub/seelog/archive/tar))
+Provides:       bundled(golang(github.com/cihub/seelog/archive/zip))
+Provides:       bundled(golang(github.com/coreos/go-systemd/activation))
+Provides:       bundled(golang(github.com/davecgh/go-spew/spew))
+Provides:       bundled(golang(github.com/docker/docker/api/types))
+Provides:       bundled(golang(github.com/docker/docker/api/types/blkiodev))
+Provides:       bundled(golang(github.com/docker/docker/api/types/container))
+Provides:       bundled(golang(github.com/docker/docker/api/types/filters))
+Provides:       bundled(golang(github.com/docker/docker/api/types/mount))
+Provides:       bundled(golang(github.com/docker/docker/api/types/network))
+Provides:       bundled(golang(github.com/docker/docker/api/types/registry))
+Provides:       bundled(golang(github.com/docker/docker/api/types/strslice))
+Provides:       bundled(golang(github.com/docker/docker/api/types/swarm))
+Provides:       bundled(golang(github.com/docker/docker/api/types/versions))
+Provides:       bundled(golang(github.com/docker/docker/opts))
+Provides:       bundled(golang(github.com/docker/docker/pkg/archive))
+Provides:       bundled(golang(github.com/docker/docker/pkg/fileutils))
+Provides:       bundled(golang(github.com/docker/docker/pkg/homedir))
+Provides:       bundled(golang(github.com/docker/docker/pkg/idtools))
+Provides:       bundled(golang(github.com/docker/docker/pkg/ioutils))
+Provides:       bundled(golang(github.com/docker/docker/pkg/jsonlog))
+Provides:       bundled(golang(github.com/docker/docker/pkg/jsonmessage))
+Provides:       bundled(golang(github.com/docker/docker/pkg/longpath))
+Provides:       bundled(golang(github.com/docker/docker/pkg/mount))
+Provides:       bundled(golang(github.com/docker/docker/pkg/pools))
+Provides:       bundled(golang(github.com/docker/docker/pkg/promise))
+Provides:       bundled(golang(github.com/docker/docker/pkg/stdcopy))
+Provides:       bundled(golang(github.com/docker/docker/pkg/system))
+Provides:       bundled(golang(github.com/docker/docker/pkg/term))
+Provides:       bundled(golang(github.com/docker/docker/pkg/term/windows))
+Provides:       bundled(golang(github.com/docker/go-connections/nat))
+Provides:       bundled(golang(github.com/docker/go-connections/sockets))
+Provides:       bundled(golang(github.com/docker/go-plugins-helpers/sdk))
+Provides:       bundled(golang(github.com/docker/go-plugins-helpers/volume))
+Provides:       bundled(golang(github.com/docker/go-units))
+Provides:       bundled(golang(github.com/fsouza/go-dockerclient))
+Provides:       bundled(golang(github.com/go-ini/ini))
+Provides:       bundled(golang(github.com/golang/mock/gomock))
+Provides:       bundled(golang(github.com/jmespath/go-jmespath))
+Provides:       bundled(golang(github.com/opencontainers/go-digest))
+Provides:       bundled(golang(github.com/opencontainers/image-spec/specs-go))
+Provides:       bundled(golang(github.com/opencontainers/image-spec/specs-go/v1))
+Provides:       bundled(golang(github.com/opencontainers/runc/libcontainer/system))
+Provides:       bundled(golang(github.com/opencontainers/runc/libcontainer/user))
+Provides:       bundled(golang(github.com/pkg/errors))
+Provides:       bundled(golang(github.com/pmezard/go-difflib/difflib))
+Provides:       bundled(golang(github.com/stretchr/testify/assert))
+Provides:       bundled(golang(golang.org/x/net/context))
+Provides:       bundled(golang(golang.org/x/net/context/ctxhttp))
+Provides:       bundled(golang(golang.org/x/net/proxy))
+Provides:       bundled(golang(golang.org/x/sys/unix))
+Provides:       bundled(golang(golang.org/x/sys/windows))
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-ExclusiveArch:  %ix86 x86_64
+ExclusiveArch:  x86_64 aarch64
 
 %description
-The Amazon Elastic Container Service initialization will start the ECS agent.
+The Amazon EC2 Container Service initialization will start the ECS agent.
 The ECS agent runs in a container and is needed to support integration
 between the aws-cli ecs command line tool and an instance running in
 Amazon EC2.
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q -n %{name}-%{version}-1
+#%patch0 -p1
+#%patch1
 
 %build
+export GO111MODULE="auto"
 ./scripts/gobuild.sh suse
 gzip -c scripts/amazon-ecs-init.1 > scripts/amazon-ecs-init.1.gz
 
@@ -61,7 +165,7 @@ touch %{buildroot}/%{_sysconfdir}/ecs/ecs.config.json
 
 mkdir -p %{buildroot}/%{_localstatedir}/cache/ecs
 touch %{buildroot}/%{_localstatedir}/cache/ecs/ecs-agent.tar
-touch %{buildroot}/%{_localstatedir}/cache/ecs/state
+echo 0 > %{buildroot}/%{_localstatedir}/cache/ecs/state
 
 %files
 %defattr(-,root,root,-)
@@ -75,7 +179,6 @@ touch %{buildroot}/%{_localstatedir}/cache/ecs/state
 %{_unitdir}/%{short_name}.service
 %{_localstatedir}/cache/ecs/ecs-agent.tar
 %{_localstatedir}/cache/ecs/state
-
 
 %pre
 %service_add_pre %{short_name}.service

--- a/packaging/suse/amazon-ecs.service
+++ b/packaging/suse/amazon-ecs.service
@@ -2,12 +2,17 @@
 Description=Amazon Elastic Container Service - container agent
 Documentation=https://aws.amazon.com/documentation/ecs/
 After=docker.service
-After=network.target
+After=network-online.target
 Requires=docker.service
-Requires=network.target
+Requires=network-online.target
 
 [Service]
 Type=simple
+Restart=on-failure
+RestartPreventExitStatus=5
+RestartSec=10s
+EnvironmentFile=-/var/lib/ecs/ecs.config
+EnvironmentFile=-/etc/ecs/ecs.config
 ExecStartPre=/usr/sbin/amazon-ecs-init pre-start
 ExecStart=/usr/sbin/amazon-ecs-init start
 ExecStop=/usr/sbin/amazon-ecs-init stop


### PR DESCRIPTION
  + Uses rpm to track the bundled dependencies
  + Update the service file to be on par with the generic-rpm and get the
    environment setting into the systemd execution environment to support
    ECS Anywhere

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
- Update the packaging data for SUSE


### Implementation details
+ Uses rpm to track the bundled dependencies
  + Update the service file to be on par with the generic-rpm and get the
    environment setting into the systemd execution environment to support
    ECS Anywhere

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
Manual test for ECS Anywhere

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
Update the packaging data for SUSE


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License:  yes 
