### PR TITLE
fix: make work with ubuntu core strict snap

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -137,7 +137,7 @@ func GetAgentPartitionBucketRegion(region string) (string, error) {
 
 // AgentConfigDirectory returns the location on disk for configuration
 func AgentConfigDirectory() string {
-	return directoryPrefix + "/etc/ecs"
+	return DirectoryPrefix + "/etc/ecs"
 }
 
 // AgentConfigFile returns the location of a file of environment variables passed to the Agent
@@ -152,7 +152,7 @@ func AgentJSONConfigFile() string {
 
 // LogDirectory returns the location on disk where logs should be placed
 func LogDirectory() string {
-	return directoryPrefix + "/var/log/ecs"
+	return DirectoryPrefix + "/var/log/ecs"
 }
 
 func initLogFile() string {
@@ -161,12 +161,12 @@ func initLogFile() string {
 
 // AgentDataDirectory returns the location on disk where state should be saved
 func AgentDataDirectory() string {
-	return directoryPrefix + "/var/lib/ecs/data"
+	return DirectoryPrefix + "/var/lib/ecs/data"
 }
 
 // CacheDirectory returns the location on disk where Agent images should be cached
 func CacheDirectory() string {
-	return directoryPrefix + "/var/cache/ecs"
+	return DirectoryPrefix + "/var/cache/ecs"
 }
 
 // CacheState returns the location on disk where cache state is stored
@@ -280,7 +280,7 @@ func parseLogOptions() map[string]string {
 
 // InstanceConfigDirectory returns the location on disk for custom instance configuration
 func InstanceConfigDirectory() string {
-	return directoryPrefix + "/var/lib/ecs"
+	return DirectoryPrefix + "/var/lib/ecs"
 }
 
 // InstanceConfigFile returns the location of a file of custom environment variables

--- a/ecs-init/config/development.go
+++ b/ecs-init/config/development.go
@@ -20,13 +20,15 @@ import (
 	"os"
 )
 
-var directoryPrefix string
+var DirectoryPrefix string
 var s3Bucket string
+
+const HomeDirectory = "/root"
 
 func init() {
 	fmt.Println("****************")
 	fmt.Println("DEVELOPMENT MODE")
-	directoryPrefix = getDirectoryPrefix()
+	DirectoryPrefix = getDirectoryPrefix()
 	s3Bucket = getS3Bucket()
 	fmt.Println("****************")
 }

--- a/ecs-init/config/release_core.go
+++ b/ecs-init/config/release_core.go
@@ -1,4 +1,4 @@
-// +build !development,!ubuntucore
+// +build !development,ubuntucore
 
 // Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -15,9 +15,14 @@
 
 package config
 
+import "os"
+
+var (
+	DirectoryPrefix = os.Getenv("SNAP_DATA")
+	HomeDirectory   = os.Getenv("SNAP_USER_DATA")
+)
+
 const (
-	DirectoryPrefix       = ""
-	DockerDirectoryPrefix = ""
-	HomeDirectory         = "/root"
+	DockerDirectoryPrefix = "/var/snap/docker/current"
 	s3Bucket              = "amazon-ecs-agent"
 )

--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -85,10 +85,10 @@ const (
 	pluginSocketFilesDir = "/run/docker/plugins"
 	// pluginSpecFilesEtcDir specifies one of the locations of spec or json files
 	// of Docker plugins
-	pluginSpecFilesEtcDir = "/etc/docker/plugins"
+	pluginSpecFilesEtcDir = config.DockerDirectoryPrefix + "/etc/docker/plugins"
 	// pluginSpecFilesUsrDir specifies one of the locations of spec or json files
 	// of Docker plugins
-	pluginSpecFilesUsrDir = "/usr/lib/docker/plugins"
+	pluginSpecFilesUsrDir = config.DockerDirectoryPrefix + "/usr/lib/docker/plugins"
 	// iptablesExecutableHostDir specifies the location of the iptable
 	// executable on the host
 	iptablesExecutableHostDir = "/sbin"
@@ -100,7 +100,7 @@ const (
 	// legacyDir holds the location of legacy iptables
 	iptablesLegacyDir = "/usr/sbin"
 	// externalEnvCredsHostDir specifies the location of the credentials on host when running in external environment.
-	externalEnvCredsHostDir = "/root/.aws"
+	externalEnvCredsHostDir = config.HomeDirectory + "/.aws"
 	// externalEnvCredsContainerDir specifies the location of the credentials that will be mounted in agent container.
 	externalEnvCredsContainerDir = "/rotatingcreds"
 
@@ -112,7 +112,7 @@ const (
 	iptablesLib64Dir    = "/lib64"
 	iptablesUsrLib64Dir = "/usr/lib64"
 
-	hostResourcesRootDir      = "/var/lib/ecs/deps"
+	hostResourcesRootDir      = config.DirectoryPrefix + "/var/lib/ecs/deps"
 	containerResourcesRootDir = "/managed-agents"
 
 	execCapabilityName     = "execute-command"

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -48,7 +49,7 @@ const (
 	// NvidiaGPUDeviceFilePattern is the pattern of GPU device files on the instance
 	NvidiaGPUDeviceFilePattern = "/dev/nvidia*"
 	// GPUInfoDirPath is the directory where gpus and driver info are saved
-	GPUInfoDirPath = "/var/lib/ecs/gpu"
+	GPUInfoDirPath = config.DirectoryPrefix + "/var/lib/ecs/gpu"
 	// NvidiaGPUInfoFilePath is the file path where gpus and driver info are saved
 	NvidiaGPUInfoFilePath = GPUInfoDirPath + "/nvidia-gpu-info.json"
 	// FilePerm is the file permissions for gpu info json file

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -19,13 +19,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 	"github.com/docker/go-plugins-helpers/volume"
 )
 
 const (
 	// VolumeMountPathPrefix is the host path where amazon ECS plugin's volumes are mounted
-	VolumeMountPathPrefix = "/var/lib/ecs/volumes/"
+	VolumeMountPathPrefix = config.DirectoryPrefix + "/var/lib/ecs/volumes/"
 	// FilePerm is the file permissions for the host volume mount directory
 	FilePerm          = 0700
 	defaultDriverType = "efs"

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -21,17 +21,18 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 )
 
 const (
 	// PluginStatePath is the directory path to the plugin state information
 	// TODO: get this value from an env var
-	PluginStatePath = "/var/lib/ecs/data/"
+	PluginStatePath = config.DirectoryPrefix + "/var/lib/ecs/data/"
 	// PluginStateFile contains the state information of the plugin
 	PluginStateFile = "ecs_volume_plugin.json"
 	// PluginStateFileAbsPath is the absolute path of the plugin state file
-	PluginStateFileAbsPath = "/var/lib/ecs/data/ecs_volume_plugin.json"
+	PluginStateFileAbsPath = config.DirectoryPrefix + "/var/lib/ecs/data/ecs_volume_plugin.json"
 )
 
 // StateManager manages the state of the volumes information


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Permits the binary to work within a strictly confined snap

ref: #425

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->

add build flag ubuntucore

use DirectoryPrefix in more places

add DockerDirectoryPrefix

add HomeDirectory due to snaps having a different structure

only mount host directories that exist due to read only filesystem


### Testing
<!-- How was this tested? -->

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

Feature: enable functionality within a strictly confined snap

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License:  yes
