### PR TITLE
Include amazon-ecs-volume-plugin and startup scripts in Debian Package

### DIFF
--- a/packaging/generic-deb/debian/README.source
+++ b/packaging/generic-deb/debian/README.source
@@ -14,3 +14,6 @@ Steps to build and install package:
 
 5. Install docker and start and enable ecs service
     sudo systemctl enable --now ecs
+
+6. Start and enable amazon-ecs-volume-plugin
+    sudo systemctl enable --now amazon-ecs-volume-plugin

--- a/packaging/generic-deb/debian/amazon-ecs-init.install
+++ b/packaging/generic-deb/debian/amazon-ecs-init.install
@@ -1,1 +1,2 @@
 amazon-ecs-init usr/libexec/
+amazon-ecs-volume-plugin usr/libexec/

--- a/packaging/generic-deb/debian/amazon-ecs-volume-plugin.service
+++ b/packaging/generic-deb/debian/amazon-ecs-volume-plugin.service
@@ -1,0 +1,27 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+After=network.target amazon-ecs-volume-plugin.socket
+Requires=amazon-ecs-volume-plugin.socket
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStart=/usr/libexec/amazon-ecs-volume-plugin
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-deb/debian/amazon-ecs-volume-plugin.socket
+++ b/packaging/generic-deb/debian/amazon-ecs-volume-plugin.socket
@@ -1,0 +1,23 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+PartOf=amazon-ecs-volume-plugin.service
+
+[Socket]
+ListenStream=/var/run/docker/plugins/amazon-ecs-volume-plugin.sock
+
+[Install]
+WantedBy=sockets.target

--- a/packaging/generic-deb/debian/rules
+++ b/packaging/generic-deb/debian/rules
@@ -20,3 +20,4 @@ override_dh_auto_install:
 	echo "2" >debian/amazon-ecs-init/var/cache/ecs/state
 	ln -s "/var/cache/ecs/ecs-agent-v${VERSION}.tar" debian/amazon-ecs-init/var/cache/ecs/ecs-agent.tar
 	dh_installsystemd --no-start --no-enable --name=ecs
+	dh_installsystemd --no-start --no-enable --name=amazon-ecs-volume-plugin


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary

This PR ensures `make deb` includes amazon-ecs-volume-plugin binary and startup scripts in the resulting Debian package

Fixes https://github.com/aws/amazon-ecs-init/issues/431


### Implementation details
Modify Debian build scripts.


### Testing
Built on Ubuntu 18.04 Bionic and tested to work.

New tests cover the changes: no

### Description for the changelog
Include amazon-ecs-volume-plugin and startup scripts in Debian package


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
