### PR TITLE
Enable AL2 support for ECS-A

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -230,6 +230,8 @@ elif echo "$ID" | grep centos; then
     DISTRO="centos"
 elif echo "$ID" | grep rhel; then
     DISTRO="rhel"
+elif [[ "$ID" == "amzn" && "$VERSION_ID" == "2" ]]; then
+    DISTRO="al2"
 fi
 
 if [ "$DISTRO" == "rhel" ]; then
@@ -260,7 +262,9 @@ if [ -x "$(command -v dnf)" ]; then
     dnf install -y jq
 elif [ -x "$(command -v yum)" ]; then
     PKG_MANAGER="yum"
-    yum install epel-release -y
+    if [ "$DISTRO" != "al2" ]; then
+        yum install epel-release -y
+    fi
     yum install -y jq
 elif [ -x "$(command -v apt)" ]; then
     PKG_MANAGER="apt"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary/Implementation details
<!-- What does this pull request do? -->
This PR updates the ECS-A installation script to make it work on AL2. It makes following changes to the script:
* Enables detection of AL2 OS and set the DISTRO variable in the script accordingly when running on AL2 instances
* Using the set DISTRO variable, bypass the 'yum install epel-release -y' command (if we don't, we get error here). This command is required for supporting Centos 7 for enabling installation of required packages (jq, docker). For AL2, these are enabled by default and not required

<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->
* Launched a non ECS optimized AL2 instance and tested by running the script to join an ECS cluster as an external instance. Then ran a simple task on it and verified the exit code is as required for a successful task completion. Also checked userdata log to verify package installation

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
