### PR TITLE
ECS-A script remove unrequired start ssm-agent

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -230,6 +230,8 @@ elif echo "$ID" | grep centos; then
     DISTRO="centos"
 elif echo "$ID" | grep rhel; then
     DISTRO="rhel"
+elif [[ "$ID" == "amzn" && "$VERSION_ID" == "2" ]]; then
+    DISTRO="al2"
 fi
 
 if [ "$DISTRO" == "rhel" ]; then
@@ -260,7 +262,9 @@ if [ -x "$(command -v dnf)" ]; then
     dnf install -y jq
 elif [ -x "$(command -v yum)" ]; then
     PKG_MANAGER="yum"
-    yum install epel-release -y
+    if [ "$DISTRO" != "al2" ]; then
+        yum install epel-release -y
+    fi
     yum install -y jq
 elif [ -x "$(command -v apt)" ]; then
     PKG_MANAGER="apt"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary / Implementation details
<!-- What does this pull request do? -->
If $NO_START variable is true, the script should not start the ssm agent. But current behavior is that it will fall through the if else clause and the ```systemctl start "$SSM_SERVICE_NAME"``` is executed irrespective of the variable. Note that it is executed twice if the variable is set to false. This change fixes it by removing the second unrequired command.

<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->
Tested by verifying instances are getting connected to cluster for centos 7 and AL2, and change goes through CI tests

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
