### PR TITLE
ECS-A script remove unrequired start ssm-agent

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -306,7 +306,6 @@ register-ssm-agent() {
         else
             echo "Skip starting ssm agent because --no-start is specified."
         fi
-        systemctl start "$SSM_SERVICE_NAME"
         echo "SSM agent has been registered."
     else
         echo "SSM agent is already registered. Managed instance ID: $SSM_MANAGED_INSTANCE_ID"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary / Implementation details
<!-- What does this pull request do? -->
If $NO_START variable is true, the script should not start the ssm agent. But current behavior is that it will fall through the if else clause and the ```systemctl start "$SSM_SERVICE_NAME"``` is executed irrespective of the variable. Note that it is executed twice if the variable is set to false. This change fixes it by removing the second unrequired command.

<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->
Tested by verifying instances are getting connected to cluster for centos 7 and AL2, and change goes through CI tests

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
