### PR TITLE
add verification to cert for exec support in ecs-a installation script

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -643,6 +643,7 @@ find-copy-certs-exec() {
         fail
     else
         echo "Using $certs"
+        openssl verify -x509_strict "$certs"
         mkdir -p $CERTS_PATH
         cp "$certs" $CERTS_PATH/tls-ca-bundle.pem
         chmod 400 $CERTS_PATH/tls-ca-bundle.pem


### PR DESCRIPTION
### Summary
Since we are allowing customers to provide a cert, verify the cert with `openssl verify`.

### Testing
Ran install script with an empty file, a self-signed TLS cert, and a copied valid cert. Script failed on first two and succeeded on next. Verified that, without this check, the ssm agent in task containers would also have issues in the first two cases and succeed on the latter.

### Licensing
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
