### PR TITLE
add amazon-ecs-volume-plugin to rpm generic package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,11 @@ BUILDROOT/ecs-agent.tar:
 
 .generic-rpm-done:
 	./scripts/update-version.sh
+	curl -O ${AGENT_URL}
 	cp packaging/generic-rpm/amazon-ecs-init.spec amazon-ecs-init.spec
 	cp packaging/generic-rpm/ecs.service ecs.service
+	cp packaging/generic-rpm/amazon-ecs-volume-plugin.service amazon-ecs-volume-plugin.service
+	cp packaging/generic-rpm/amazon-ecs-volume-plugin.socket amazon-ecs-volume-plugin.socket
 	tar -czf ./sources.tgz ecs-init scripts
 	test -e SOURCES || ln -s . SOURCES
 	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecs-init.spec

--- a/packaging/generic-rpm/README.md
+++ b/packaging/generic-rpm/README.md
@@ -1,0 +1,22 @@
+##Steps to build and install package:
+
+* Install build and install dependencies
+  ```
+  rpm-build make golang-go gcc git wget rpmdevtools 
+  ```
+* Build the package by running 
+  ```
+  make generic-rpm
+  ```
+* Install docker via docker repos: https://docs.docker.com/engine/install/
+* Install the package using built `.rpm` file from previous step
+* (Only needed if EFS is needed) Install `efs-utils` following instructions on https://docs.aws.amazon.com/efs/latest/ug/installing-amazon-efs-utils.html#installing-other-distro
+* Start and enable ecs service
+  ```
+  sudo systemctl enable --now ecs
+  ```
+* (Only needed if EFS is needed) Start and enable ecs volume plugin 
+  ```
+  sudo systemctl enable --now amazon-ecs-volume-plugin
+  ```
+

--- a/packaging/generic-rpm/amazon-ecs-init.spec
+++ b/packaging/generic-rpm/amazon-ecs-init.spec
@@ -16,6 +16,7 @@
 %global _cachedir %{_localstatedir}/cache
 %global bundled_agent_version %{version}
 %global no_exec_perm 644
+%global debug_package %{nil}
 
 %ifarch x86_64
 %global agent_image %{SOURCE3}
@@ -38,6 +39,8 @@ Source2:        ecs.service
 Source3:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-v%{bundled_agent_version}.tar
 # aarch64 Container agent docker image
 Source4:        https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-arm64-v%{bundled_agent_version}.tar
+Source5:        amazon-ecs-volume-plugin.service
+Source6:        amazon-ecs-volume-plugin.socket
 
 BuildRequires:  golang >= 1.7
 BuildRequires:  systemd
@@ -58,6 +61,7 @@ required routes among its preparation steps.
 
 %install
 install -D amazon-ecs-init %{buildroot}%{_libexecdir}/amazon-ecs-init
+install -D amazon-ecs-volume-plugin %{buildroot}%{_libexecdir}/amazon-ecs-volume-plugin
 install -m %{no_exec_perm} -D scripts/amazon-ecs-init.1 %{buildroot}%{_mandir}/man1/amazon-ecs-init.1
 
 mkdir -p %{buildroot}%{_sysconfdir}/ecs
@@ -73,10 +77,13 @@ install -m %{no_exec_perm} %{agent_image} %{buildroot}%{_cachedir}/ecs/
 mkdir -p %{buildroot}%{_sharedstatedir}/ecs/data
 
 install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
+install -m %{no_exec_perm} -D %{SOURCE5} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.service
+install -m %{no_exec_perm} -D %{SOURCE6} $RPM_BUILD_ROOT/%{_unitdir}/amazon-ecs-volume-plugin.socket
 
 %files
 %{_libexecdir}/amazon-ecs-init
 %{_mandir}/man1/amazon-ecs-init.1*
+%{_libexecdir}/amazon-ecs-volume-plugin
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config
 %config(noreplace) %ghost %{_sysconfdir}/ecs/ecs.config.json
 %ghost %{_cachedir}/ecs/ecs-agent.tar
@@ -84,14 +91,18 @@ install -m %{no_exec_perm} -D %{SOURCE2} $RPM_BUILD_ROOT/%{_unitdir}/ecs.service
 %{_cachedir}/ecs/state
 %dir %{_sharedstatedir}/ecs/data
 %{_unitdir}/ecs.service
+%{_unitdir}/amazon-ecs-volume-plugin.service
+%{_unitdir}/amazon-ecs-volume-plugin.socket
 
 %post
 # Symlink the bundled ECS Agent at loadable path.
 ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 %systemd_post ecs
+%systemd_post amazon-ecs-volume-plugin.service
 
 %postun
-%systemd_postun
+%systemd_postun ecs.service
+%systemd_postun_with_restart amazon-ecs-volume-plugin
 
 %changelog
 * Fri Dec 03 2021 Mythri Garaga Mannjunatha <mythr@amazon.com> - 1.57.1-1

--- a/packaging/generic-rpm/amazon-ecs-volume-plugin.service
+++ b/packaging/generic-rpm/amazon-ecs-volume-plugin.service
@@ -1,0 +1,27 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+After=network.target amazon-ecs-volume-plugin.socket
+Requires=amazon-ecs-volume-plugin.socket
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStart=/usr/libexec/amazon-ecs-volume-plugin
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/generic-rpm/amazon-ecs-volume-plugin.socket
+++ b/packaging/generic-rpm/amazon-ecs-volume-plugin.socket
@@ -1,0 +1,23 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License
+
+[Unit]
+Description=Amazon Elastic Container Service Volume Plugin
+PartOf=amazon-ecs-volume-plugin.service
+
+[Socket]
+ListenStream=/var/run/docker/plugins/amazon-ecs-volume-plugin.sock
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add `amazon-ecs-volume-plugin` to `generic-rpm` package

### Implementation details
<!-- How are the changes implemented?
If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Mostly the same as https://github.com/aws/amazon-ecs-init/pull/433. Fixed some minor issue, added readme and did some tests.

### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no --> N/A
* MACIS ecs-a tests passed with .rpm package built by code change
* Install package on a fedora34 instance and successfully run a task with EFS in task definintion.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
yes