### PR TITLE
downgrade ssm binary version for exec

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -651,7 +651,7 @@ find-copy-certs-exec() {
 }
 
 download-ssm-binaries-exec() {
-    BINARY_VERSION="3.1.501.0"
+    BINARY_VERSION="3.1.90.0"
     BINARY_PATH="/var/lib/ecs/deps/execute-command/bin/${BINARY_VERSION}"
     BINARY_DOWNLOAD_PATH="ssm-binaries"
 


### PR DESCRIPTION
### Summary
Downgrading the ssm version for exec to be consistent with the one used in our [amis for EC2](https://github.com/aws/amazon-ecs-ami/blob/main/variables.pkr.hcl#L59). 

### Testing
Testing included
- ran tasks with the `start-task` and `run-task` apis and exec'd into the tasks
- create a service with the execute command enabled and exec'd into a task started by the service
- verified that logging to cloudwatch and s3 still worked
- verified that encrypting data with KMS still worked
- curl'd for the binary file in a few regions (us-west-2, cn-north-1, eu-west-1, ap-south-1)

### Description for the changelog
downgrade ssm binary version for exec

### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
