### PR TITLE
build al2 rpm in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ If you think you’ve found a potential security issue, please do not post it in
 
 ## Development
 
+#### Building the RPM for test
+
+On your local machine, you can use the docker target to generate an rpm:
+
+```
+make rpm-in-docker
+```
+
+This rpm can then be installed in an amazon linux ami:
+
+```
+# send rpm either through s3 or scp
+rpm -i rpm-that-you-built.rpm
+sudo systemctl enable ecs
+sudo systemctl start ecs
+```
+
 #### Dev dependencies
 
 Run `make get-deps` to get dependencies for running tests and generating mocks.

--- a/scripts/dockerfiles/build.dockerfile
+++ b/scripts/dockerfiles/build.dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && yum install -y golang make tar rpm-build
+WORKDIR /workspace/amazon-ecs-init
+# we're going to run the build as the non-privileged user, so we need write access to the directory
+RUN chmod -R 777 /workspace
+CMD /bin/bash -c 'make rpm'


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This lets us use the command `make rpm-in-docker` to build locally. This
is a good approximation of an authorative build that we can use to test
changes to init.

### Testing
<!-- How was this tested? -->

```
make rpm-in-docker
```

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License:  yes


### Implementation Details

This is currently hardcoded to al2 -- but we can amend it in the future to include an option to build the generic rpm as well.