### PR TITLE
feat: permit building ecs-init that will run inside a strict snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /amazon-ecs-init*
+/amazon-ecs-volume-plugin
 /BUILDROOT/
 /x86_64/
 /sources.tar

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ bin/dep:
 static:
 	./scripts/gobuild.sh
 
+snap-compatible:
+	./scripts/gobuild.sh snap
+
 govet:
 	go vet ./...
 

--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -164,6 +164,21 @@ func AgentDataDirectory() string {
 	return directoryPrefix + "/var/lib/ecs/data"
 }
 
+// ResolveDirectory prepends the directory prefix (if required) to the given directory
+func ResolveDirectory(directory string) string {
+	return directoryPrefix + directory
+}
+
+// ResolveDockerDirectory prepends any potential prefix for a docker filesystem (within snap)
+func ResolveDockerDirectory(directory string) string {
+	return dockerDirectoryPrefix + directory
+}
+
+// HomeDirectory returns the home directory of the root user
+func HomeDirectory() string {
+	return homeDirectory
+}
+
 // CacheDirectory returns the location on disk where Agent images should be cached
 func CacheDirectory() string {
 	return directoryPrefix + "/var/cache/ecs"

--- a/ecs-init/config/development.go
+++ b/ecs-init/config/development.go
@@ -1,3 +1,4 @@
+//go:build development
 // +build development
 
 // Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -22,6 +23,9 @@ import (
 
 var directoryPrefix string
 var s3Bucket string
+
+const homeDirectory = "/root"
+const dockerDirectoryPrefix = ""
 
 func init() {
 	fmt.Println("****************")

--- a/ecs-init/config/release_snap.go
+++ b/ecs-init/config/release_snap.go
@@ -1,5 +1,5 @@
-//go:build !development && !snap
-// +build !development,!snap
+//go:build !development && snap
+// +build !development,snap
 
 // Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -16,9 +16,14 @@
 
 package config
 
+import "os"
+
 const (
-	directoryPrefix       = ""
-	dockerDirectoryPrefix = ""
-	homeDirectory         = "/root"
 	s3Bucket              = "amazon-ecs-agent"
+	dockerDirectoryPrefix = "/var/snap/docker/current"
+)
+
+var (
+	directoryPrefix = os.Getenv("SNAP_DATA")
+	homeDirectory   = os.Getenv("SNAP_USER_DATA")
 )

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -31,16 +31,6 @@ func getPlatformSpecificEnvVariables() map[string]string {
 // createHostConfig creates the host config for the ECS Agent container
 // It mounts leases and pid file directories when built for Amazon Linux AMI
 func createHostConfig(binds []string) *godocker.HostConfig {
-	binds = append(binds,
-		config.ProcFS+":"+hostProcDir+readOnly,
-		iptablesUsrLibDir+":"+iptablesUsrLibDir+readOnly,
-		iptablesLibDir+":"+iptablesLibDir+readOnly,
-		iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+readOnly,
-		iptablesLib64Dir+":"+iptablesLib64Dir+readOnly,
-		iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+readOnly,
-		iptablesAltDir+":"+iptablesAltDir+readOnly,
-		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
-	)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 

--- a/ecs-init/gpu/nvidia_gpu_manager.go
+++ b/ecs-init/gpu/nvidia_gpu_manager.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
@@ -47,10 +48,6 @@ type NvidiaGPUManager struct {
 const (
 	// NvidiaGPUDeviceFilePattern is the pattern of GPU device files on the instance
 	NvidiaGPUDeviceFilePattern = "/dev/nvidia*"
-	// GPUInfoDirPath is the directory where gpus and driver info are saved
-	GPUInfoDirPath = "/var/lib/ecs/gpu"
-	// NvidiaGPUInfoFilePath is the file path where gpus and driver info are saved
-	NvidiaGPUInfoFilePath = GPUInfoDirPath + "/nvidia-gpu-info.json"
 	// FilePerm is the file permissions for gpu info json file
 	FilePerm = 0700
 	// nvidiaEULAAgreementInfo is the EULA agreement that we want to show to the customers when using
@@ -59,8 +56,15 @@ const (
 		"https://www.nvidia.com/en-us/about-nvidia/eula-agreement/"
 )
 
-// ErrNoGPUDeviceFound is thrown when it is not a ECS GPU instance
-var ErrNoGPUDeviceFound = errors.New("No GPU device files found on the instance")
+var (
+	// ErrNoGPUDeviceFound is thrown when it is not a ECS GPU instance
+	ErrNoGPUDeviceFound = errors.New("No GPU device files found on the instance")
+
+	// GPUInfoDirPath is the directory where gpus and driver info are saved
+	GPUInfoDirPath = config.ResolveDirectory("/var/lib/ecs/gpu")
+	// NvidiaGPUInfoFilePath is the file path where gpus and driver info are saved
+	NvidiaGPUInfoFilePath = GPUInfoDirPath + "/nvidia-gpu-info.json"
+)
 
 // NewNvidiaGPUManager is used to obtain NvidiaGPUManager handle
 func NewNvidiaGPUManager() GPUManager {

--- a/ecs-init/volumes/ecs_volume_plugin.go
+++ b/ecs-init/volumes/ecs_volume_plugin.go
@@ -19,16 +19,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 	"github.com/docker/go-plugins-helpers/volume"
 )
 
 const (
-	// VolumeMountPathPrefix is the host path where amazon ECS plugin's volumes are mounted
-	VolumeMountPathPrefix = "/var/lib/ecs/volumes/"
 	// FilePerm is the file permissions for the host volume mount directory
 	FilePerm          = 0700
 	defaultDriverType = "efs"
+)
+
+var (
+	// VolumeMountPathPrefix is the host path where amazon ECS plugin's volumes are mounted
+	VolumeMountPathPrefix = config.ResolveDirectory("/var/lib/ecs/volumes/")
 )
 
 // AmazonECSVolumePlugin holds list of volume drivers and volumes information

--- a/ecs-init/volumes/state_manager.go
+++ b/ecs-init/volumes/state_manager.go
@@ -21,17 +21,21 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/aws/amazon-ecs-init/ecs-init/config"
 	"github.com/cihub/seelog"
 )
 
 const (
-	// PluginStatePath is the directory path to the plugin state information
-	// TODO: get this value from an env var
-	PluginStatePath = "/var/lib/ecs/data/"
 	// PluginStateFile contains the state information of the plugin
 	PluginStateFile = "ecs_volume_plugin.json"
+)
+
+var (
+	// PluginStatePath is the directory path to the plugin state information
+	// TODO: get this value from an env var
+	PluginStatePath = config.ResolveDirectory("/var/lib/ecs/data/")
 	// PluginStateFileAbsPath is the absolute path of the plugin state file
-	PluginStateFileAbsPath = "/var/lib/ecs/data/ecs_volume_plugin.json"
+	PluginStateFileAbsPath = config.ResolveDirectory("/var/lib/ecs/data/ecs_volume_plugin.json")
 )
 
 // StateManager manages the state of the volumes information


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Permits the binary to work within a strictly confined snap

ref: aws/containers-roadmap#1487

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->

* add go build flag `snap`

* add make target `snap-compatible`

* add `config.ResolveDirectory()` and `config.ResolveDockerDirectory()` to add prefixes to paths where required

* add `config.HomeDirectory()` due to snaps having a different structure and different home directory

* only mount host directories into agent container that exist due to read only filesystem

### Testing
<!-- How was this tested? -->

Building a strictly confined snap and running on Ubuntu Core 20

New tests cover the changes: <!-- yes|no --> no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

> Feature - enable functionality within a strictly confined snap when built with `snap` build flag

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
