### PR TITLE
fix(docker): check for iptables directories before adding to list of binds

### DIFF
--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -31,16 +31,6 @@ func getPlatformSpecificEnvVariables() map[string]string {
 // createHostConfig creates the host config for the ECS Agent container
 // It mounts leases and pid file directories when built for Amazon Linux AMI
 func createHostConfig(binds []string) *godocker.HostConfig {
-	binds = append(binds,
-		config.ProcFS+":"+hostProcDir+readOnly,
-		iptablesUsrLibDir+":"+iptablesUsrLibDir+readOnly,
-		iptablesLibDir+":"+iptablesLibDir+readOnly,
-		iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+readOnly,
-		iptablesLib64Dir+":"+iptablesLib64Dir+readOnly,
-		iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+readOnly,
-		iptablesAltDir+":"+iptablesAltDir+readOnly,
-		iptablesLegacyDir+":"+iptablesLegacyDir+readOnly,
-	)
 
 	logConfig := config.AgentDockerLogDriverConfiguration()
 

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -33,8 +33,8 @@ import (
 const (
 	testTempDirPrefix = "init-docker-test-"
 
-	expectedAgentBindsUnspecifiedPlatform = 21
-	expectedAgentBindsSuseUbuntuPlatform  = 18
+	expectedAgentBindsUnspecifiedPlatform = 14
+	expectedAgentBindsSuseUbuntuPlatform  = 13
 )
 
 var expectedAgentBinds = expectedAgentBindsUnspecifiedPlatform
@@ -258,8 +258,8 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 		expectedAgentBinds = expectedAgentBindsSuseUbuntuPlatform
 	}
 
-	if len(hostCfg.Binds) != expectedAgentBinds {
-		t.Errorf("Expected exactly %d elements to be in Binds, but was %d", expectedAgentBinds, len(hostCfg.Binds))
+	if len(hostCfg.Binds) < expectedAgentBinds {
+		t.Errorf("Expected at least %d elements to be in Binds, but was %d", expectedAgentBinds, len(hostCfg.Binds))
 	}
 	binds := make(map[string]struct{})
 	for _, binding := range hostCfg.Binds {
@@ -272,13 +272,6 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 	expectKey(config.AgentConfigDirectory()+":"+config.AgentConfigDirectory(), binds, t)
 	expectKey(config.CacheDirectory()+":"+config.CacheDirectory(), binds, t)
 	expectKey(config.ProcFS+":"+hostProcDir+":ro", binds, t)
-	expectKey(iptablesUsrLibDir+":"+iptablesUsrLibDir+":ro", binds, t)
-	expectKey(iptablesLibDir+":"+iptablesLibDir+":ro", binds, t)
-	expectKey(iptablesUsrLib64Dir+":"+iptablesUsrLib64Dir+":ro", binds, t)
-	expectKey(iptablesLib64Dir+":"+iptablesLib64Dir+":ro", binds, t)
-	expectKey(iptablesExecutableHostDir+":"+iptablesExecutableContainerDir+":ro", binds, t)
-	expectKey(iptablesAltDir+":"+iptablesAltDir+":ro", binds, t)
-	expectKey(iptablesLegacyDir+":"+iptablesLegacyDir+":ro", binds, t)
 	expectKey(config.LogDirectory()+"/exec:/log/exec", binds, t)
 	for _, pluginDir := range pluginDirs {
 		expectKey(pluginDir+":"+pluginDir+readOnly, binds, t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Permits ecs-init to work on a read only root file system

fixes aws/amazon-ecs-agent#3152

This previously did not work due to docker attempting to create host directories that did not exist and stopping the ecs-agent container from starting

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->

check for directory existing prior to adding to slice of binds

### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no --> no - existing tests are sufficient

Currently have modified tests to not be as strict. Open for alternative suggestions.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->

Bug - permit ecs-agent to start on a readonly root file system

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes --> yes
