### PR TITLE
refactor md5 to sha256

### DIFF
--- a/ecs-init/config/common.go
+++ b/ecs-init/config/common.go
@@ -188,13 +188,13 @@ func AgentRemoteTarballKey() (string, error) {
 	return fmt.Sprintf("%s.tar", name), nil
 }
 
-// AgentRemoteTarballMD5Key is the remote file of a md5sum used to verify the integrity of the AgentRemoteTarball
-func AgentRemoteTarballMD5Key() (string, error) {
+// AgentRemoteTarballSHA256Key is the remote file of a sha256sum used to verify the integrity of the AgentRemoteTarball
+func AgentRemoteTarballSHA256Key() (string, error) {
 	tarballKey, err := AgentRemoteTarballKey()
 	if err != nil {
 		return "", err
 	}
-	return tarballKey + ".md5", nil
+	return tarballKey + ".sha256", nil
 }
 
 // DesiredImageLocatorFile returns the location on disk of a well-known file describing an Agent image to load


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Change all usage of MD5 to SHA256 as MD5 now is considered a broken crypto system.

### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
Replacing all MD5 related code to SHA256

### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->
Yes

Verified by 
1. Build init rpm
2. Install rpm on AL2 instance
3. Clear local agent cache by deleting agent tar under `/var/cache/ecs`
4. Run `sudo /usr/libexec/amazon-ecs-init reload-cache`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Change all usage of MD5 to SHA256.

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
