### PR TITLE
[AL2022] Set GO111MODULE=auto and update ecs-init.spec

### DIFF
--- a/packaging/amazon-linux-ami/ecs-init.spec
+++ b/packaging/amazon-linux-ami/ecs-init.spec
@@ -23,6 +23,7 @@
 %global _cachedir %{_localstatedir}/cache
 %global bundled_agent_version %{version}
 %global no_exec_perm 644
+%global debug_package %{nil}
 
 %ifarch x86_64
 %global agent_image %{SOURCE3}
@@ -224,7 +225,7 @@ ln -sf %{basename:%{agent_image}} %{_cachedir}/ecs/ecs-agent.tar
 %systemd_post amazon-ecs-volume-plugin.service
 
 %postun
-%systemd_postun
+%systemd_postun ecs
 %systemd_postun_with_restart amazon-ecs-volume-plugin
 
 %else

--- a/scripts/gobuild.sh
+++ b/scripts/gobuild.sh
@@ -18,6 +18,7 @@ export TOPWD="$(pwd)"
 export BUILDDIR="$(mktemp -d)"
 export GOPATH="${TOPWD}/ecs-init/:${BUILDDIR}"
 export SRCPATH="${BUILDDIR}/src/github.com/aws/amazon-ecs-init"
+export GO111MODULE="auto"
 
 if [ -d "${TOPWD}/.git" ]; then
     version=$(cat "${TOPWD}/ecs-init/ECSVERSION")


### PR DESCRIPTION
### Summary
This PR updates `packaging/amazon-linux-ami/ecs-init.spec` and `scripts/gobuild.sh` for packing ecs-init rpm for [Amazon Linux 2022 (AL220)](https://aws.amazon.com/linux/amazon-linux-2022/faqs/) OS.
  
### Implementation details
1. Add `%global debug_package %{nil}` in amazon-linux-ami/ecs-init.spec to fix `RPM build errors: Empty %files file...`.
2. Append an argument `ecs` after %systemd_postun` in amazon-linux-ami/ecs-init.spec to fix `error: The %systemd_postun macro requires some arguments`.
3. Set `GO111MODULE="auto"` in  gobuild.sh to only use go modules if modules exist.
  
### Testing
1. Built ecs-init rpm on an AL2022 instance (x86_64 and aarch64), installed ECS Agent version 1.58 from the rpm, and ran ECS tasks successfully.
2. Built ecs-init rpm in an AL1 and AL2 (x86_64 and aarch64) using Koji, installed ECS Agent version 1.59 from the rpm, and ran ECS tasks successfully.

New tests cover the changes: no

### Description for the changelog
Support building ecs-init rpm on AL2022 OS.


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
