### PR TITLE
Remove the hardcoded amazon-ssm-agent fingerprint validation from ecs-anywhere-install.sh

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -372,13 +372,6 @@ ssm-agent-signature-verify() {
     fi
 
     curl-helper "$dir/amazon-ssm-agent.gpg" "https://raw.githubusercontent.com/aws/amazon-ecs-init/master/scripts/amazon-ssm-agent.gpg"
-    local fp
-    fp=$(gpg --quiet --with-colons --with-fingerprint "$dir/amazon-ssm-agent.gpg" | awk -F: '$1 == "fpr" {print $10;}')
-    echo "$fp"
-    if [ "$fp" != "8108A07A9EBE248E3F1C63F254F4F56E693ECA21" ]; then
-        echo "amazon-ssm-agent GPG public key fingerprint verification fail. Stop the installation of the amazon-ssm-agent. Please contact AWS Support."
-        fail
-    fi
     gpg --import "$dir/amazon-ssm-agent.gpg"
 
     if gpg --verify "$1" "$2"; then


### PR DESCRIPTION
### Summary
This PR removes the hardcoded amazon-ssm-agent fingerprint validation from ecs-anywhere-install.sh.

We're maintaining GPG verification of the SSM agent rpm. The signature of amazon-ssm-agent rpm has been verified before installation as below.
```
    if gpg --verify "$1" "$2"; then
        echo "amazon-ssm-agent GPG verification passed. Install the amazon-ssm-agent."
    else
        echo "amazon-ssm-agent GPG verification failed. Stop the installation of the amazon-ssm-agent. Please contact AWS Support."
        fail
    fi
```


### Implementation details
Lines for the hardcoded amazon-ssm-agent fingerprint validation are removed from ecs-anywhere-install.sh.

### Testing
Tested on ubuntu amd64 in us-west-2
* Launch an EC2 instance (AMI name: ubuntu-minimal/images/hvm-ssd/ubuntu-focal-20.04-amd64-minimal-20220308)
* ssh into the instance and uninstall amazon-ssm-agent
* Run the updated ecs-anywhere-install.sh on the instance
* Verified the instance is registered to both SSM and ECS cluster

```
##########################
# Trying to install ssm agent ... 


##########################
# Trying to verify the signature of amazon-ssm-agent package ... 

/usr/bin/gpg
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: key 54F4F56E693ECA21: 1 signature not checked due to a missing key
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 54F4F56E693ECA21: public key "SSM Agent <ssm-agent-signer@amazon.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: no ultimately trusted keys found
gpg: Signature made Wed Mar  9 21:49:55 2022 UTC
gpg:                using RSA key 54F4F56E693ECA21
gpg: Good signature from "SSM Agent <ssm-agent-signer@amazon.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 8108 A07A 9EBE 248E 3F1C  63F2 54F4 F56E 693E CA21
amazon-ssm-agent GPG verification passed. Install the amazon-ssm-agent.

# ok
##########################

Selecting previously unselected package amazon-ssm-agent.
(Reading database ... 47928 files and directories currently installed.)
Preparing to unpack .../tmp.AUp5nb5MfD/ssm-agent.deb ...
Preparing for install
-> Systemd detected
active
Failed to stop amazon-ssm-agent.service: Unit amazon-ssm-agent.service not loaded.
Unpacking amazon-ssm-agent (3.1.1080.0-1) ...
Setting up amazon-ssm-agent (3.1.1080.0-1) ...
Starting agent
Created symlink /etc/systemd/system/multi-user.target.wants/amazon-ssm-agent.service → /lib/systemd/system/amazon-ssm-agent.service.

##########################
# Trying to Register SSM agent ... 

Error occurred fetching the seelog config file path:  open /etc/amazon/ssm/seelog.xml: no such file or directory
Initializing new seelog logger
New Seelog Logger Creation Complete
2022-03-23 18:50:00 WARN Could not read InstanceFingerprint file: InstanceFingerprint does not exist.
2022-03-23 18:50:00 INFO No initial fingerprint detected, generating fingerprint file...
2022-03-23 18:50:00 INFO Successfully registered the instance with AWS SSM using Managed instance-id: mi-07e5e1287440fca0a
SSM agent has been registered.

# ok
##########################
```
New tests cover the changes: no

### Description for the changelog
Remove the hardcoded amazon-ssm-agent fingerprint validation from ecs-anywhere-install.sh


### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
