### PR TITLE
ECS now supports cgroups v2

### DIFF
--- a/scripts/ecs-anywhere-install.sh
+++ b/scripts/ecs-anywhere-install.sh
@@ -152,13 +152,6 @@ if [ ! -d /run/systemd/system ]; then
     fail
 fi
 
-if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
-    echo "Your system is using cgroups v2, which is not supported by ECS."
-    echo "Please change your system to cgroups v1 and reboot. If your system has grubby, we suggest using the following command:"
-    echo '    sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0" && sudo shutdown -r now'
-    fail
-fi
-
 SSM_SERVICE_NAME="amazon-ssm-agent"
 SSM_BIN_NAME="amazon-ssm-agent"
 if systemctl is-enabled snap.amazon-ssm-agent.amazon-ssm-agent.service &>/dev/null; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
ECS now supports cgroups v2 and no longer needs to block the install in this case.

Reference:
https://github.com/aws/containers-roadmap/issues/1535
https://github.com/aws/amazon-ecs-agent/pull/3127


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->
I removed the flow logic that bails if it detects cgroups v2.

### Testing
<!-- How was this tested? -->
I have been able to successfully run the install script and get a properly running ECS agent in docker on a cgroups v2 debian bullseye docker container.

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->
Bug - Install script no longer fails on systems using cgroups v2

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
