### PR TITLE
Add GO111MODULE=on to honnef.co/go/tools/cmd/staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ get-deps:
 	GO111MODULE=on go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/golang/mock/mockgen
-	go get honnef.co/go/tools/cmd/staticcheck
+	GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.2.1
 
 clean:
 	-rm -f ecs-init.spec


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Add `GO111MODULE=on` to honnef.co/go/tools/cmd/staticcheck to make `make get-deps` happy in the PR CI build checks. Sample PR where this check failed - https://github.com/aws/amazon-ecs-init/pull/503

Identical to https://github.com/aws/amazon-ecs-agent/pull/3193


### Implementation details
<!-- How are the changes implemented?

If you have included new dependencies, please ensure you have followed
Packaging guidance from
https://github.com/aws/amazon-ecs-init/blob/master/CONTRIBUTING.md
-->


### Testing
<!-- How was this tested? -->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog. Prefix the summary with an
indication of the change type, Feature, Enhancement, or Bug. Here is an example:
Feature - Upgrade the something library to the latest stable version 1.2.3
-->


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
