### PR TITLE
Add the CAP_CHOWN capability to support running rootless

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -79,6 +79,11 @@ const (
 	// For more information on setns, please read this manpage:
 	// http://man7.org/linux/man-pages/man2/setns.2.html
 	CapSysAdmin = "SYS_ADMIN"
+	// CapChown to start agent with CAP_CHOWN capability
+	// This is needed for the ECS Agent to invoke the chown call when
+	// configuring the files for configuration or administration.
+	// http://man7.org/linux/man-pages/man2/chown.2.html
+	CapChown = "CAP_CHOWN"
 	// DefaultCgroupMountpoint is the default mount point for the cgroup subsystem
 	DefaultCgroupMountpoint = "/sys/fs/cgroup"
 	// pluginSocketFilesDir specifies the location of UNIX domain socket files of

--- a/ecs-init/docker/docker_config.go
+++ b/ecs-init/docker/docker_config.go
@@ -49,7 +49,7 @@ func createHostConfig(binds []string) *godocker.HostConfig {
 		// CapNetAdmin and CapSysAdmin are needed for running task in awsvpc network mode.
 		// This network mode is (at least currently) not supported in external environment,
 		// hence not adding them in that case.
-		caps = []string{CapNetAdmin, CapSysAdmin}
+		caps = []string{CapNetAdmin, CapSysAdmin, CapChown}
 	}
 
 	hostConfig := &godocker.HostConfig{

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -288,7 +288,7 @@ func validateCommonCreateContainerOptions(opts godocker.CreateContainerOptions, 
 		t.Errorf("Expected network mode to be %s, got %s", networkMode, hostCfg.NetworkMode)
 	}
 
-	if len(hostCfg.CapAdd) != 2 {
+	if len(hostCfg.CapAdd) != 3 {
 		t.Error("Mismatch detected in added host config capabilities")
 	}
 


### PR DESCRIPTION
### Summary
EcsInit needs to be able to change the ownership of files/directories for ServiceConnect and potentially existing features as well. This ensures it can do that even if running rootless.


### Implementation details
Add CAP_CHOWN to list of privileged capabilities.


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
