### PR TITLE
Extend the mounting to include all dependencies

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -117,9 +117,7 @@ const (
 	containerResourcesRootDir = "/managed-agents"
 
 	execCapabilityName     = "execute-command"
-	execBinRelativePath    = "bin"
 	execConfigRelativePath = "config"
-	execCertsRelativePath  = "certs"
 
 	execAgentLogRelativePath = "/exec"
 )
@@ -432,7 +430,7 @@ func (c *client) getHostConfig(envVarsFromFiles map[string]string) *godocker.Hos
 	binds = append(binds, getDockerPluginDirBinds()...)
 
 	// only add bind mounts when the src file/directory exists on host; otherwise docker API create an empty directory on host
-	binds = append(binds, getCapabilityExecBinds()...)
+	binds = append(binds, getCapabilityBinds()...)
 
 	return createHostConfig(binds)
 }
@@ -468,31 +466,24 @@ func getDockerPluginDirBinds() []string {
 	return pluginBinds
 }
 
-func getCapabilityExecBinds() []string {
-	hostResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
-	containerResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
+func getCapabilityBinds() []string {
+	var binds = []string{}
 
-	var binds []string
-
-	// bind mount the entire /host/dependency/path/execute-command/bin folder
-	hostBinDir := filepath.Join(hostResourcesDir, execBinRelativePath)
-	if isPathValid(hostBinDir, true) {
+	// bind mount the entire /host/dependency/path/ folder
+	// as readonly to support all managed dependencies
+	if isPathValid(hostResourcesRootDir, true) {
 		binds = append(binds,
-			hostBinDir+":"+filepath.Join(containerResourcesDir, execBinRelativePath)+readOnly)
+			hostResourcesRootDir+":"+containerResourcesRootDir+readOnly)
 	}
 
 	// bind mount the entire /host/dependency/path/execute-command/config folder
 	// in read-write mode to allow ecs-agent to write config files to host file system
 	// (docker will) create the config folder if it does not exist
-	hostConfigDir := filepath.Join(hostResourcesDir, execConfigRelativePath)
-	binds = append(binds,
-		hostConfigDir+":"+filepath.Join(containerResourcesDir, execConfigRelativePath))
-
-	// bind mount the entire /host/dependency/path/execute-command/certs folder
-	hostCertsDir := filepath.Join(hostResourcesDir, execCertsRelativePath)
-	if isPathValid(hostCertsDir, true) {
+	hostConfigDir := filepath.Join(hostResourcesRootDir, execCapabilityName, execConfigRelativePath)
+	// Check that execute-command folder is present not config folder
+	if isPathValid(filepath.Dir(hostConfigDir), true) {
 		binds = append(binds,
-			hostCertsDir+":"+filepath.Join(containerResourcesDir, execCertsRelativePath)+readOnly)
+			hostConfigDir+":"+filepath.Join(containerResourcesRootDir, execCapabilityName, execConfigRelativePath))
 	}
 
 	return binds

--- a/ecs-init/docker/docker_test.go
+++ b/ecs-init/docker/docker_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	testTempDirPrefix = "init-docker-test-"
 
-	expectedAgentBindsUnspecifiedPlatform = 21
+	expectedAgentBindsUnspecifiedPlatform = 20
 	expectedAgentBindsSuseUbuntuPlatform  = 18
 )
 
@@ -827,21 +827,13 @@ func TestStartAgentWithExecBinds(t *testing.T) {
 	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
 	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
-	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
-
 	// config
 	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
 
-	// certs
-	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
-	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
-
 	expectedExecBinds := []string{
-		hostBinDir + ":" + containerBinDir + readOnly,
-		hostCertsDir + ":" + containerCertsDir + readOnly,
+		hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
+		hostConfigDir + ":" + containerConfigDir,
 	}
 	expectedAgentBinds += len(expectedExecBinds)
 
@@ -884,17 +876,9 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 	hostCapabilityExecResourcesDir := filepath.Join(hostResourcesRootDir, execCapabilityName)
 	containerCapabilityExecResourcesDir := filepath.Join(containerResourcesRootDir, execCapabilityName)
 
-	// binaries
-	hostBinDir := filepath.Join(hostCapabilityExecResourcesDir, execBinRelativePath)
-	containerBinDir := filepath.Join(containerCapabilityExecResourcesDir, execBinRelativePath)
-
 	// config
 	hostConfigDir := filepath.Join(hostCapabilityExecResourcesDir, execConfigRelativePath)
 	containerConfigDir := filepath.Join(containerCapabilityExecResourcesDir, execConfigRelativePath)
-
-	// certs
-	hostCertsDir := filepath.Join(hostCapabilityExecResourcesDir, execCertsRelativePath)
-	containerCertsDir := filepath.Join(containerCapabilityExecResourcesDir, execCertsRelativePath)
 
 	testCases := []struct {
 		name            string
@@ -907,19 +891,17 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 				return true
 			},
 			expectedBinds: []string{
-				hostBinDir + ":" + containerBinDir + readOnly,
+				hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
 				hostConfigDir + ":" + containerConfigDir,
-				hostCertsDir + ":" + containerCertsDir + readOnly,
 			},
 		},
 		{
-			name: "only ssm-agent bin path valid",
+			name: "managed-agents path valid, no execute-command",
 			testIsPathValid: func(path string, isDir bool) bool {
-				return path == hostBinDir
+				return path == hostResourcesRootDir
 			},
 			expectedBinds: []string{
-				hostBinDir + ":" + containerBinDir + readOnly,
-				hostConfigDir + ":" + containerConfigDir,
+				hostResourcesRootDir + ":" + containerResourcesRootDir + readOnly,
 			},
 		},
 		{
@@ -927,15 +909,13 @@ func TestGetCapabilityExecBinds(t *testing.T) {
 			testIsPathValid: func(path string, isDir bool) bool {
 				return false
 			},
-			expectedBinds: []string{
-				hostConfigDir + ":" + containerConfigDir,
-			},
+			expectedBinds: []string{},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isPathValid = tc.testIsPathValid
-			binds := getCapabilityExecBinds()
+			binds := getCapabilityBinds()
 			assert.Equal(t, tc.expectedBinds, binds)
 		})
 	}


### PR DESCRIPTION
### Summary
This results in the same set of folders available for ExecCommand support
but also includes as RO the whole /var/lib/ecs/deps/ tree for additional
features such as ServiceConnect to reuse without adding additional mounts.


### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: <!-- yes -->
